### PR TITLE
Fix typo so that font variant dropdown opens correctly

### DIFF
--- a/js/views/font-variant-dropdown.js
+++ b/js/views/font-variant-dropdown.js
@@ -12,7 +12,7 @@ module.exports = DropdownTemplate.extend( {
 
 	render: function() {
 		this.$el.html( '' );
-		if ( this.selectedAvailableFont && this.fvdAdjust ) {
+		if ( this.selectedAvailableFont && this.type.fvdAdjust ) {
 			var variantOptions = this.selectedAvailableFont.getFontVariantOptions();
 			for ( var k in variantOptions ) {
 				this.$el.append( new FontVariantOption( {


### PR DESCRIPTION
Small typo in https://github.com/Automattic/custom-fonts/commit/2d5aeec57a10f648f7e4b2fe6ca91833a9b40ade caused the font variant dropdown to not display correctly.
