### PR TITLE
Move the Fonts section to match wpcom

### DIFF
--- a/custom-fonts.php
+++ b/custom-fonts.php
@@ -110,7 +110,8 @@ class Jetpack_Fonts {
 	public function register_controls( $wp_customize ) {
 		require dirname( __FILE__ ) . '/fonts-customize-control.php';
 		$wp_customize->add_section( 'jetpack_fonts', array(
-			'title' => __( 'Fonts' )
+			'title' =>    __( 'Fonts' ),
+			'priority' => 52
 		) );
 		$wp_customize->add_setting( self::OPTION . '[selected_fonts]', array(
 			'type'      => 'option',


### PR DESCRIPTION
Below Site Title and Colors, above Header Image.
Fixes #41
