### PR TITLE
Bind live preview init on `preview-ready` event

### DIFF
--- a/js/helpers/live-update.js
+++ b/js/helpers/live-update.js
@@ -28,6 +28,10 @@ function init() {
 			liveUpdateFontsInPreview( selectedFonts );
 		} );
 	} );
+	// The Customizer doesn't give us the initial value,
+	// so do it manually on first run
+	liveUpdateFontsInPreview( api( 'jetpack_fonts[selected_fonts]').get() );
+
 }
 
 module.exports = {


### PR DESCRIPTION
This ensures that our `ProviderView`s are bound before we start reacting to changes.
