### PR TITLE
Don't allow `inherit` in a font stack

### DIFF
--- a/css-generator.php
+++ b/css-generator.php
@@ -264,7 +264,7 @@ class Jetpack_Fonts_Css_Generator {
 		foreach( $rules as $rule ) {
 			switch( $rule['property'] ) {
 				case 'font-family':
-					$value = $font['cssName'] . ',' . $rule['value'];
+					$value = $this->maybe_font_stack( $font['cssName'], $rule['value'] );
 					break;
 				case 'font-weight':
 					$value = $this->pick_weight( $font );
@@ -283,6 +283,13 @@ class Jetpack_Fonts_Css_Generator {
 			}
 		}
 		return implode( $declaration_sep, $css_rules );
+	}
+
+	private function maybe_font_stack( $font_name, $original ) {
+		if ( $original === 'inherit' ) {
+			return $font_name;
+		}
+		return $font_name . ',' . $original;
 	}
 
 	private function shim_rules_for_type( $rules, $type ) {

--- a/js/helpers/preview-styles.js
+++ b/js/helpers/preview-styles.js
@@ -43,6 +43,7 @@ function generateCssForAnnotation( style, annotation ) {
 function generateFontFamily( family, annotation ) {
 	var families = [ '"' + family + '"' ];
 	var annotationFamily = getFontFamilyFromAnnotation( annotation );
+	console.log( 'GODDAMN', annotationFamily, annotation, family );
 	if ( annotationFamily ) {
 		families.push( annotationFamily );
 	}
@@ -55,7 +56,7 @@ function getFontFamilyFromAnnotation( annotation ) {
 	}
 	var original;
 	annotation.rules.forEach( function( rule ) {
-		if ( rule.value && rule.property === 'font-family' ) {
+		if ( rule.value && rule.property === 'font-family' && 'inherit' !== rule.value ) {
 			original = rule.value;
 		}
 	} );

--- a/tests/js/preview-styles.js
+++ b/tests/js/preview-styles.js
@@ -125,6 +125,10 @@ describe( 'PreviewStyles', function() {
 			expect( PreviewStyles.generateCssFromStyles( currentFontData ) ).to.match( /\.site-title/ );
 			expect( PreviewStyles.generateCssFromStyles( currentFontData ) ).to.match( /\.entry-title/ );
 		} );
+
+		it( 'does not return inherit in a font stack', function(){
+			expect( PreviewStyles.generateCssFromStyles( currentFontData ) ).to.not.match( /, ?inherit/ );
+		});
 	} );
 
 	describe( '.createStyleElementWith()', function() {

--- a/tests/php/css-generator-Test.php
+++ b/tests/php/css-generator-Test.php
@@ -123,6 +123,11 @@ class Jetpack_Fonts_Css_Generator_Test extends PHPUnit_Framework_TestCase {
 		$this->assertRegExp( '/body[^{]+\{[^}]*font-style:\s?italic/', $generator->get_css( $this->fonts_for_css ) );
 	}
 
+	public function test_does_not_return_inherit_in_a_font_stack() {
+		$generator = new Jetpack_Fonts_Css_Generator;
+		$this->assertNotRegExp( '/, ?inherit/', $generator->get_css( $this->fonts_for_css ) );
+	}
+
 	public function test_get_css_returns_normal_font_weight_for_invalid_data() {
 		$generator = new Jetpack_Fonts_Css_Generator;
 		$fonts_for_css = array(


### PR DESCRIPTION
With tests!

Fixes #107
