### PR TITLE
Use percentages insted of px for font control width

### DIFF
--- a/css/fonts-customizer.css
+++ b/css/fonts-customizer.css
@@ -101,7 +101,7 @@ h3.jetpack-fonts__type-header {
 	display: inline-block;
 	position: relative;
 	font-size: 14px;
-	width: 134px;
+	width: 48%;
 	cursor: pointer;
 	margin: 0px 0px 10px 0px;
 }
@@ -120,7 +120,7 @@ h3.jetpack-fonts__type-header {
 	top: 0px;
 	z-index: 11;
 	background: #f5f5f5;
-	width: 134px;
+	width: 100%;
 	border-radius: 3px;
 	border: 1px solid silver;
 }


### PR DESCRIPTION
Fixes the view when a scrollbar is added to the font controls 
![screen shot 2015-05-04 at 12 40 13 pm](https://cloud.githubusercontent.com/assets/232343/7457703/97b5940c-f25c-11e4-844c-4694aedca4be.png)
