### PR TITLE
Make tests pass for rendering CurrentFontVariant

### DIFF
--- a/tests/js/font-variant-control.js
+++ b/tests/js/font-variant-control.js
@@ -52,8 +52,9 @@ describe( 'FontVariantControl', function() {
 		} );
 
 		it( 'renders a CurrentFontVariant', function() {
-			var currentFont = new AvailableFont();
+			var currentFont = new AvailableFont( {fvds: [ 'n4', 'i7' ]} );
 			var availableFonts = new Backbone.Collection();
+			availableFonts.add( currentFont );
 			fontVariantControl = new FontVariantControl({ currentFont: currentFont, fontData: availableFonts, type: headingsTextType });
 			Backbone.$( 'body' ).append( fontVariantControl.render().el );
 			expect( Backbone.$( '.jetpack-fonts__current-font-variant' ) ).to.have.length.above( 0 );


### PR DESCRIPTION
CurrentFontVariant is now only rendered if the font has multiple fvds, so we need to update the tests to reflect that.
