### PR TITLE
Split addFontToPage into two separate methods

### DIFF
--- a/js/helpers/live-update.js
+++ b/js/helpers/live-update.js
@@ -6,18 +6,18 @@ var api = require( '../helpers/api' ),
 // Initialize the default Provider Views
 require( '../providers/google' );
 
-function addFontToPage( font ) {
+function addFontToPreview( font ) {
 	var ProviderView = getViewForProvider( font.provider );
 	if ( ! ProviderView ) {
 		debug( 'live update failed because no provider could be found for', font );
 		return;
 	}
-	ProviderView.addFontToPage( font );
+	ProviderView.addFontToPreview( font );
 }
 
 function liveUpdateFontsInPreview( selectedFonts ) {
 	debug( 'rendering live update for new styles', selectedFonts );
-	selectedFonts.forEach( addFontToPage );
+	selectedFonts.forEach( addFontToPreview );
 	PreviewStyles.writeFontStyles( selectedFonts );
 }
 

--- a/js/providers/google.js
+++ b/js/providers/google.js
@@ -6,12 +6,20 @@ var WebFont = require( '../helpers/webfont' );
 
 var loadedFontIds = [];
 
-function addFontToPage( font, text ) {
+function addFontToControls( font, text ) {
 	if ( ~ loadedFontIds.indexOf( font.id ) ) {
 		return;
 	}
 	loadedFontIds.push( font.id );
 	WebFont.load( { google: { families: [ font.id ], text: text } } );
+}
+
+function addFontToPreview( font ) {
+	if ( ~ loadedFontIds.indexOf( font.id ) ) {
+		return;
+	}
+	loadedFontIds.push( font.id );
+	WebFont.load( { google: { families: [ font.id ] } } );
 }
 
 var GoogleProviderView = api.JetpackFonts.ProviderView.extend({
@@ -46,12 +54,12 @@ var GoogleProviderView = api.JetpackFonts.ProviderView.extend({
 		} else {
 			this.$el.removeClass( 'active' );
 		}
-		addFontToPage( this.model.toJSON(), this.model.get( 'id' ) );
+		addFontToControls( this.model.toJSON(), this.model.get( 'id' ) );
 		return this;
 	}
 });
 
-GoogleProviderView.addFontToPage = addFontToPage;
+GoogleProviderView.addFontToPreview = addFontToPreview;
 
 api.JetpackFonts.providerViews.google = GoogleProviderView;
 

--- a/js/views/dropdown-item.js
+++ b/js/views/dropdown-item.js
@@ -5,7 +5,7 @@ var Emitter = require( '../helpers/emitter' );
 // An individual font in the dropdown list, exported as
 // `api.JetpackFonts.ProviderView`. Extend this object for each provider. The
 // extended objects need to define a `render` method to render their provider's
-// font name, as well as an `addFontToPage` method on the object itself.
+// font name, as well as `addFontToControls` and `addFontToPreview` methods on the object itself.
 var ProviderView = Backbone.View.extend({
 	className: 'jetpack-fonts__option',
 
@@ -35,6 +35,6 @@ var ProviderView = Backbone.View.extend({
 	}
 });
 
-ProviderView.addFontToPage = function() {};
+ProviderView.addFontToControls = function() {};
 
 module.exports = ProviderView;


### PR DESCRIPTION
This will be useful for having different sets of Google fonts load for the preview and controls sidebar.

Use in conjunction with https://github.com/Automattic/custom-fonts-typekit/pull/21
