### PR TITLE
Don't print fonts in PHP in the Customizer

### DIFF
--- a/custom-fonts.php
+++ b/custom-fonts.php
@@ -131,7 +131,7 @@ class Jetpack_Fonts {
 
 	/** Renders fonts and font CSS if we have any fonts. */
 	public function maybe_render_fonts() {
-		if ( ! $this->get_fonts() ) {
+		if ( ! $this->get_fonts() || is_customize_preview() ) {
 			return;
 		}
 


### PR DESCRIPTION
They are already being output by JS and this leads
to duplication of efforts and weird behaviour by Typekit.

Fixes #130

Typekit won't render properly until #139 is in place (It already won't
work past the first rendered weight).
