### PR TITLE
Remove menu width property so menu inherits parent width

### DIFF
--- a/css/fonts-customizer.css
+++ b/css/fonts-customizer.css
@@ -72,7 +72,9 @@ h3.jetpack-fonts__type-header {
 	z-index: 11;
 	background-color: #FFFFFF;
 	line-height: 2.2;
-	width: 277px;
+	width: 100%;
+	-moz-box-sizing: border-box;
+	box-sizing: border-box;
 	border-top-left-radius: 3px;
 	border-top-right-radius: 3px;
 	border: 1px solid #C0C0C0;


### PR DESCRIPTION
I think this fixes #115 but maybe not. 

Before:

![screen shot 2015-05-27 at 6 01 26 pm](https://cloud.githubusercontent.com/assets/2036909/7848519/6a7947a4-049a-11e5-91ac-d1d9a803b74b.png)

After:

![screen shot 2015-05-27 at 3 42 29 pm](https://cloud.githubusercontent.com/assets/2036909/7848507/55fae29c-049a-11e5-851a-847ce27b39e3.png)
