### PR TITLE
Pin backbone dependency version to prevent test errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "homepage": "https://github.com/Automattic/custom-fonts",
   "devDependencies": {
     "babel-eslint": "^3.1.17",
-    "backbone": "^1.1.2",
+    "backbone": "~1.1.2",
     "chai": "^2.2.0",
     "eslint": "^0.23.0",
     "grunt": "~0.4.5",


### PR DESCRIPTION
The backbone dependency for testing was set to `^1.1.2` which was upgrading to
1.2.1. Apparently at that version the way we bundle in jsdom's document object
was no longer working, resulting it lots of test failures.

Using a tilde prevents us from leaving 1.1.x, which allows all tests to pass.

To test this, remove your `node_modules` folder, if present, or do a clean install of the repo. Then run `npm install` and finally `grunt test`. The tests will fail without this change.
