### PR TITLE
Load providers earlier

### DIFF
--- a/Providers.md
+++ b/Providers.md
@@ -18,10 +18,10 @@ Since `Jetpack_Font_Provider` is an abstract class, the required members and met
 
 ### Register your class
 
-Your class should not self-instantiate in its file. The Custom Fonts plugin manages everything and will use autoloading to include it when needed.
+Your class should not self-instantiate in its file. The Custom Fonts plugin manages everything and will use autoloading to include it when needed. Register your class no later than the `setup_theme` action.
 
 ```php
-add_action( 'jetpack_fonts_register', 'my_fonts_providerr_register' );
+add_action( 'jetpack_fonts_register', 'my_fonts_provider_register' );
 function my_fonts_provider_register( $jetpack_fonts ) {
 	/**
 	 * Register your custom fonts provider with three required variables

--- a/custom-fonts.php
+++ b/custom-fonts.php
@@ -75,7 +75,7 @@ class Jetpack_Fonts {
 	 */
 	public function init() {
 		spl_autoload_register( array( $this, 'autoloader' ) );
-		add_action( 'init', array( $this, 'register_providers' ), 11 );
+		add_action( 'setup_theme', array( $this, 'register_providers' ), 11 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_render_fonts' ) );
 		add_action( 'customize_register', array( $this, 'register_controls' ) );
 		add_action( 'customize_preview_init', array( $this, 'add_preview_scripts' ) );
@@ -498,7 +498,7 @@ class Jetpack_Fonts {
 }
 
 // Hook things up geddit hooks.
-add_action( 'init', array( Jetpack_Fonts::get_instance(), 'init' ) );
+add_action( 'setup_theme', array( Jetpack_Fonts::get_instance(), 'init' ), 9 );
 register_activation_hook( __FILE__, array( 'Jetpack_Fonts', 'on_activate' ) );
 register_deactivation_hook( __FILE__, array( 'Jetpack_Fonts', 'on_deactivate' ) );
 


### PR DESCRIPTION
In some cases, `init` action can be too late for providers, which
may need to talk to servers in response to purchasing activities.
