### PR TITLE
Reduce the priority of the css output from 11 to 10

### DIFF
--- a/custom-fonts.php
+++ b/custom-fonts.php
@@ -121,7 +121,7 @@ class Jetpack_Fonts {
 			return;
 		}
 
-		add_action( 'wp_head', array( $this, 'render_font_css' ), 11 );
+		add_action( 'wp_head', array( $this, 'render_font_css' ), 10 );
 
 		$webfont_options = array();
 


### PR DESCRIPTION
This allows custom-css output to be printed before custom-fonts.

Fixes https://github.com/Automattic/custom-fonts/issues/229

I'm not sure if there's some specific reason the priority was set to 11 to begin with, though.
