### PR TITLE
Handle the case where selected_fonts is an object instead of an array

### DIFF
--- a/js/helpers/live-update.js
+++ b/js/helpers/live-update.js
@@ -19,6 +19,7 @@ function validateSelectedFonts( selectedFonts ) {
 	if ( selectedFonts.length ) {
 		return selectedFonts;
 	}
+	debug( 'warning: selectedFonts is not an array. trying to convert', selectedFonts );
 	var keys = Object.keys( selectedFonts );
 	if ( ! keys || ! keys.length ) {
 		return [];


### PR DESCRIPTION
There are cases where the PHP array is 1-indexed instead of 0-indexed, in which
case the data serialized to JS becomes an object instead of an array. This tries
to handle such situations gracefully.
