### PR TITLE
Update the font picker dropdown to have a smaller border radius so there's no gap between the edge of the arrow/x and the picker, and make the arrow/x area wider so there's even spacing on both sides.

### DIFF
--- a/css/fonts-customizer.css
+++ b/css/fonts-customizer.css
@@ -42,11 +42,11 @@ h3.jetpack-fonts__type-header {
 	content: "\f347";
 	font: 400 20px/1 dashicons;
 	cursor: pointer;
-	border-radius: 0 3px 3px 0;
+	border-radius: 0 2px 2px 0;
 	color: #6A6A6A;
 	background-color: #fff;
 	font-size: 24px;
-	width: 28px;
+	width: 32px;
 	height: 45px;
 	line-height: 45px;
 	text-align: center;


### PR DESCRIPTION
Before:
<img width="292" alt="screen shot 2016-01-08 at 6 45 53 pm" src="https://cloud.githubusercontent.com/assets/2846578/12212565/02803886-b63a-11e5-9199-d39b7ecb0fed.png">

After:
<img width="296" alt="screen shot 2016-01-08 at 6 46 36 pm" src="https://cloud.githubusercontent.com/assets/2846578/12212566/06491b40-b63a-11e5-89c5-dcd5fb2ed1ec.png">

(Screenshots from WordPress.com)
