### PR TITLE
Require Jetpack_Fonts_Control only once

### DIFF
--- a/custom-fonts.php
+++ b/custom-fonts.php
@@ -126,7 +126,7 @@ class Jetpack_Fonts {
 		if ( ! $this->get_generator()->has_rules() ) {
 			return;
 		}
-		require dirname( __FILE__ ) . '/fonts-customize-control.php';
+		require_once dirname( __FILE__ ) . '/fonts-customize-control.php';
 		$wp_customize->add_section( 'jetpack_fonts', array(
 			'title' =>    __( 'Fonts' ),
 			'priority' => 52


### PR DESCRIPTION
Multiple calls to the customizer_register action would cause an error,
as Jetpack_Fonts_Control is declared more than once.
This was found running core tests, in particular
test_save_changeset_post_with_varying_users.