### PR TITLE
Update Cached Data file

### DIFF
--- a/providers/google.json
+++ b/providers/google.json
@@ -11,7 +11,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Abel",
@@ -24,7 +24,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Abhaya+Libre",
@@ -39,11 +39,11 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
+      "sinhala",
       "latin-ext",
-      "sinhala"
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Abril+Fatface",
@@ -54,8 +54,8 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
     "bodyText": false
   },
@@ -70,7 +70,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Acme",
@@ -83,7 +83,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Actor",
@@ -96,7 +96,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Adamina",
@@ -109,7 +109,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Advent+Pro",
@@ -126,11 +126,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "greek",
-      "latin",
-      "latin-ext"
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Aguafina+Script",
@@ -141,10 +141,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Akronim",
@@ -155,10 +155,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Aladin",
@@ -169,10 +169,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Aldrich",
@@ -185,7 +185,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Alef",
@@ -200,7 +200,7 @@
       "hebrew",
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Alegreya",
@@ -220,13 +220,13 @@
     ],
     "genericFamily": "serif",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
     "bodyText": true
   },
@@ -248,15 +248,15 @@
     ],
     "genericFamily": "serif",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Alegreya+Sans",
@@ -280,13 +280,13 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
     "bodyText": true
   },
@@ -312,15 +312,15 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Aleo",
@@ -336,10 +336,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Alex+Brush",
@@ -350,10 +350,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Alfa+Slab+One",
@@ -364,11 +364,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Alice",
@@ -379,11 +379,11 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
       "cyrillic",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Alike",
@@ -396,7 +396,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Alike+Angular",
@@ -409,7 +409,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Allan",
@@ -421,10 +421,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Allerta",
@@ -437,7 +437,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Allerta+Stencil",
@@ -450,7 +450,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Allura",
@@ -461,10 +461,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Almendra",
@@ -478,10 +478,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Almendra+Display",
@@ -492,10 +492,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Almendra+SC",
@@ -508,7 +508,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Amarante",
@@ -519,10 +519,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Amaranth",
@@ -538,7 +538,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Amatic+SC",
@@ -550,13 +550,13 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "hebrew",
-      "latin",
-      "vietnamese",
       "cyrillic",
-      "latin-ext"
+      "hebrew",
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Amethysta",
@@ -569,7 +569,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Amiko",
@@ -583,10 +583,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Amiri",
@@ -600,11 +600,11 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
+      "arabic",
       "latin-ext",
-      "arabic"
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Amita",
@@ -617,10 +617,10 @@
     "genericFamily": "cursive",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Anaheim",
@@ -631,10 +631,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Andada",
@@ -645,10 +645,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Andika",
@@ -659,13 +659,13 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Angkor",
@@ -678,7 +678,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Annie+Use+Your+Telescope",
@@ -691,7 +691,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Anonymous+Pro",
@@ -705,10 +705,10 @@
     ],
     "genericFamily": "monospace",
     "subsets": [
-      "greek",
-      "latin",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "greek",
+      "latin"
     ],
     "bodyText": true
   },
@@ -723,7 +723,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Antic+Didone",
@@ -736,7 +736,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Antic+Slab",
@@ -749,7 +749,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Anton",
@@ -760,11 +760,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Arapey",
@@ -778,7 +778,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Arbutus",
@@ -789,10 +789,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Arbutus+Slab",
@@ -803,10 +803,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Architects+Daughter",
@@ -819,7 +819,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Archivo",
@@ -837,11 +837,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Archivo+Black",
@@ -852,10 +852,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Archivo+Narrow",
@@ -873,11 +873,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Aref+Ruqaa",
@@ -889,10 +888,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "arabic"
+      "arabic",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Arima+Madurai",
@@ -910,12 +909,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "tamil",
-      "vietnamese",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Arimo",
@@ -929,14 +928,14 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "cyrillic",
       "hebrew",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
     "bodyText": true
   },
@@ -949,10 +948,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Armata",
@@ -963,10 +962,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Arsenal",
@@ -980,13 +979,13 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Artifika",
@@ -999,7 +998,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Arvo",
@@ -1015,7 +1014,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Arya",
@@ -1028,10 +1027,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Asap",
@@ -1049,11 +1048,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Asap+Condensed",
@@ -1071,11 +1070,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Asar",
@@ -1087,10 +1086,10 @@
     "genericFamily": "serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Asset",
@@ -1103,7 +1102,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Assistant",
@@ -1122,7 +1121,7 @@
       "hebrew",
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Astloch",
@@ -1136,7 +1135,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Asul",
@@ -1150,7 +1149,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Athiti",
@@ -1166,12 +1165,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Atma",
@@ -1186,11 +1185,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "bengali",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Atomic+Age",
@@ -1203,7 +1202,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Aubrey",
@@ -1216,7 +1215,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Audiowide",
@@ -1227,10 +1226,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Autour+One",
@@ -1241,10 +1240,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Average",
@@ -1255,10 +1254,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Average+Sans",
@@ -1269,10 +1268,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Averia+Gruesa+Libre",
@@ -1283,10 +1282,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Averia+Libre",
@@ -1304,7 +1303,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Averia+Sans+Libre",
@@ -1322,7 +1321,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Averia+Serif+Libre",
@@ -1340,7 +1339,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "B612",
@@ -1356,7 +1355,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "B612+Mono",
@@ -1372,7 +1371,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bad+Script",
@@ -1383,10 +1382,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "cyrillic"
+      "cyrillic",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bahiana",
@@ -1397,10 +1396,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bahianita",
@@ -1411,11 +1410,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bai+Jamjuree",
@@ -1437,12 +1436,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Baloo",
@@ -1454,11 +1453,11 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Baloo+Bhai",
@@ -1470,11 +1469,11 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "gujarati",
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Baloo+Bhaijaan",
@@ -1485,12 +1484,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
+      "arabic",
       "latin-ext",
-      "arabic"
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Baloo+Bhaina",
@@ -1502,11 +1501,11 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "oriya",
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Baloo+Chettan",
@@ -1517,12 +1516,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "malayalam",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Baloo+Da",
@@ -1533,12 +1532,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "bengali",
-      "vietnamese",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Baloo+Paaji",
@@ -1550,11 +1549,11 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "gurmukhi",
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Baloo+Tamma",
@@ -1565,12 +1564,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "kannada",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Baloo+Tammudu",
@@ -1581,12 +1580,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
+      "latin-ext",
       "telugu",
-      "vietnamese",
-      "latin-ext"
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Baloo+Thambi",
@@ -1597,12 +1596,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "tamil",
-      "vietnamese",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Balthazar",
@@ -1615,7 +1614,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bangers",
@@ -1626,11 +1625,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Barlow",
@@ -1658,11 +1657,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Barlow+Condensed",
@@ -1690,11 +1689,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Barlow+Semi+Condensed",
@@ -1722,11 +1721,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Barriecito",
@@ -1737,11 +1736,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Barrio",
@@ -1752,10 +1751,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Basic",
@@ -1766,10 +1765,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Battambang",
@@ -1783,7 +1782,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Baumans",
@@ -1796,7 +1795,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bayon",
@@ -1809,7 +1808,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Belgrano",
@@ -1822,7 +1821,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bellefair",
@@ -1834,10 +1833,10 @@
     "genericFamily": "serif",
     "subsets": [
       "hebrew",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Belleza",
@@ -1848,10 +1847,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "BenchNine",
@@ -1864,10 +1863,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bentham",
@@ -1880,7 +1879,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Berkshire+Swash",
@@ -1891,23 +1890,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
-    ],
-    "bodyText": false
-  },
-  {
-    "id": "Beth+Ellen",
-    "cssName": "Beth Ellen",
-    "displayName": "Beth Ellen",
-    "fvds": [
-      "n4"
-    ],
-    "genericFamily": "cursive",
-    "subsets": [
+      "latin-ext",
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bevan",
@@ -1918,11 +1904,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bigelow+Rules",
@@ -1933,10 +1919,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bigshot+One",
@@ -1949,7 +1935,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bilbo",
@@ -1960,10 +1946,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bilbo+Swash+Caps",
@@ -1974,10 +1960,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "BioRhyme",
@@ -1992,10 +1978,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "BioRhyme+Expanded",
@@ -2010,10 +1996,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Biryani",
@@ -2031,10 +2017,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bitter",
@@ -2047,10 +2033,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Black+And+White+Picture",
@@ -2061,10 +2047,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Black+Han+Sans",
@@ -2075,10 +2061,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Black+Ops+One",
@@ -2089,31 +2075,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
-  },
-  {
-    "id": "Blinker",
-    "cssName": "Blinker",
-    "displayName": "Blinker",
-    "fvds": [
-      "n1",
-      "n2",
-      "n3",
-      "n4",
-      "n6",
-      "n7",
-      "n8",
-      "n9"
-    ],
-    "genericFamily": "sans-serif",
-    "subsets": [
-      "latin",
-      "latin-ext"
-    ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bokor",
@@ -2126,7 +2091,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bonbon",
@@ -2139,7 +2104,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Boogaloo",
@@ -2152,7 +2117,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bowlby+One",
@@ -2165,7 +2130,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bowlby+One+SC",
@@ -2176,10 +2141,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Brawler",
@@ -2192,7 +2157,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bree+Serif",
@@ -2203,10 +2168,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bubblegum+Sans",
@@ -2217,10 +2182,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bubbler+One",
@@ -2231,10 +2196,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Buda",
@@ -2247,7 +2212,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Buenard",
@@ -2259,10 +2224,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bungee",
@@ -2273,11 +2238,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bungee+Hairline",
@@ -2288,11 +2253,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bungee+Inline",
@@ -2303,11 +2268,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bungee+Outline",
@@ -2318,11 +2283,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Bungee+Shade",
@@ -2333,11 +2298,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Butcherman",
@@ -2348,10 +2313,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Butterfly+Kids",
@@ -2362,10 +2327,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cabin",
@@ -2383,11 +2348,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cabin+Condensed",
@@ -2401,11 +2366,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cabin+Sketch",
@@ -2419,7 +2384,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Caesar+Dressing",
@@ -2432,7 +2397,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cagliostro",
@@ -2445,7 +2410,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cairo",
@@ -2461,11 +2426,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
+      "arabic",
       "latin-ext",
-      "arabic"
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Calligraffitti",
@@ -2478,7 +2443,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cambay",
@@ -2493,10 +2458,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cambo",
@@ -2509,7 +2474,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Candal",
@@ -2522,7 +2487,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cantarell",
@@ -2538,7 +2503,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cantata+One",
@@ -2549,10 +2514,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cantora+One",
@@ -2563,10 +2528,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Capriola",
@@ -2577,10 +2542,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cardo",
@@ -2593,12 +2558,12 @@
     ],
     "genericFamily": "serif",
     "subsets": [
+      "latin-ext",
       "greek",
       "greek-ext",
-      "latin",
-      "latin-ext"
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Carme",
@@ -2611,7 +2576,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Carrois+Gothic",
@@ -2624,7 +2589,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Carrois+Gothic+SC",
@@ -2637,7 +2602,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Carter+One",
@@ -2650,7 +2615,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Catamaran",
@@ -2669,11 +2634,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "tamil",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Caudex",
@@ -2687,12 +2652,12 @@
     ],
     "genericFamily": "serif",
     "subsets": [
+      "latin-ext",
       "greek",
       "greek-ext",
-      "latin",
-      "latin-ext"
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Caveat",
@@ -2704,12 +2669,12 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Caveat+Brush",
@@ -2720,10 +2685,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cedarville+Cursive",
@@ -2736,7 +2701,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ceviche+One",
@@ -2747,10 +2712,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Chakra+Petch",
@@ -2770,12 +2735,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Changa",
@@ -2792,11 +2757,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
+      "arabic",
       "latin-ext",
-      "arabic"
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Changa+One",
@@ -2810,7 +2775,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Chango",
@@ -2821,10 +2786,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Charm",
@@ -2836,12 +2801,12 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Charmonman",
@@ -2853,12 +2818,12 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Chathura",
@@ -2873,10 +2838,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "telugu"
+      "telugu",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Chau+Philomene+One",
@@ -2888,10 +2853,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Chela+One",
@@ -2902,10 +2867,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Chelsea+Market",
@@ -2916,10 +2881,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Chenla",
@@ -2932,7 +2897,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cherry+Cream+Soda",
@@ -2945,7 +2910,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cherry+Swash",
@@ -2957,8 +2922,8 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
     "bodyText": false
   },
@@ -2973,7 +2938,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Chicle",
@@ -2984,10 +2949,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Chivo",
@@ -3005,10 +2970,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Chonburi",
@@ -3019,12 +2984,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cinzel",
@@ -3037,8 +3002,8 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
     "bodyText": false
   },
@@ -3055,7 +3020,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Clicker+Script",
@@ -3066,10 +3031,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Coda",
@@ -3081,10 +3046,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Coda+Caption",
@@ -3095,10 +3060,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Codystar",
@@ -3110,10 +3075,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Coiny",
@@ -3124,12 +3089,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "tamil",
-      "vietnamese",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Combo",
@@ -3140,10 +3105,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Comfortaa",
@@ -3158,14 +3123,14 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "greek",
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Coming+Soon",
@@ -3178,7 +3143,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Concert+One",
@@ -3189,10 +3154,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Condiment",
@@ -3203,10 +3168,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Content",
@@ -3220,7 +3185,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Contrail+One",
@@ -3233,7 +3198,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Convergence",
@@ -3246,7 +3211,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cookie",
@@ -3259,7 +3224,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Copse",
@@ -3272,7 +3237,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Corben",
@@ -3284,10 +3249,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cormorant",
@@ -3307,13 +3272,13 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cormorant+Garamond",
@@ -3333,13 +3298,13 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cormorant+Infant",
@@ -3359,13 +3324,13 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cormorant+SC",
@@ -3380,13 +3345,13 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cormorant+Unicase",
@@ -3401,13 +3366,13 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cormorant+Upright",
@@ -3422,11 +3387,11 @@
     ],
     "genericFamily": "serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Courgette",
@@ -3437,10 +3402,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cousine",
@@ -3454,16 +3419,16 @@
     ],
     "genericFamily": "monospace",
     "subsets": [
+      "cyrillic",
       "hebrew",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Coustard",
@@ -3477,7 +3442,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Covered+By+Your+Grace",
@@ -3490,7 +3455,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Crafty+Girls",
@@ -3503,7 +3468,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Creepster",
@@ -3516,7 +3481,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Crete+Round",
@@ -3528,40 +3493,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
-  },
-  {
-    "id": "Crimson+Pro",
-    "cssName": "Crimson Pro",
-    "displayName": "Crimson Pro",
-    "fvds": [
-      "n2",
-      "n3",
-      "n4",
-      "n5",
-      "n6",
-      "n7",
-      "n8",
-      "n9",
-      "i2",
-      "i3",
-      "i4",
-      "i5",
-      "i6",
-      "i7",
-      "i8",
-      "i9"
-    ],
-    "genericFamily": "serif",
-    "subsets": [
-      "latin",
-      "vietnamese",
-      "latin-ext"
-    ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Crimson+Text",
@@ -3579,7 +3514,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Croissant+One",
@@ -3590,10 +3525,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Crushed",
@@ -3606,7 +3541,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cuprum",
@@ -3620,13 +3555,13 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cute+Font",
@@ -3637,10 +3572,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cutive",
@@ -3651,10 +3586,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Cutive+Mono",
@@ -3665,10 +3600,10 @@
     ],
     "genericFamily": "monospace",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "DM+Sans",
@@ -3684,10 +3619,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "DM+Serif+Display",
@@ -3699,10 +3634,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "DM+Serif+Text",
@@ -3714,10 +3649,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Damion",
@@ -3730,7 +3665,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Dancing+Script",
@@ -3742,11 +3677,11 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Dangrek",
@@ -3759,7 +3694,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Darker+Grotesque",
@@ -3776,11 +3711,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "David+Libre",
@@ -3794,11 +3729,11 @@
     "genericFamily": "serif",
     "subsets": [
       "hebrew",
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Dawning+of+a+New+Day",
@@ -3811,7 +3746,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Days+One",
@@ -3824,7 +3759,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Dekko",
@@ -3836,10 +3771,10 @@
     "genericFamily": "cursive",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Delius",
@@ -3852,7 +3787,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Delius+Swash+Caps",
@@ -3865,7 +3800,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Delius+Unicase",
@@ -3879,7 +3814,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Della+Respira",
@@ -3892,7 +3827,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Denk+One",
@@ -3903,10 +3838,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Devonshire",
@@ -3917,10 +3852,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Dhurjati",
@@ -3931,10 +3866,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "telugu"
+      "telugu",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Didact+Gothic",
@@ -3945,14 +3880,14 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "greek",
-      "greek-ext",
-      "latin",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Diplomata",
@@ -3963,10 +3898,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Diplomata+SC",
@@ -3977,10 +3912,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Do+Hyeon",
@@ -3991,10 +3926,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Dokdo",
@@ -4005,10 +3940,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Domine",
@@ -4020,10 +3955,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Donegal+One",
@@ -4034,10 +3969,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Doppio+One",
@@ -4048,10 +3983,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Dorsa",
@@ -4064,7 +3999,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Dosis",
@@ -4081,11 +4016,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Dr+Sugiyama",
@@ -4096,10 +4030,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Duru+Sans",
@@ -4110,10 +4044,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Dynalight",
@@ -4124,10 +4058,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "EB+Garamond",
@@ -4147,15 +4081,15 @@
     ],
     "genericFamily": "serif",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Eagle+Lake",
@@ -4166,10 +4100,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "East+Sea+Dokdo",
@@ -4180,10 +4114,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Eater",
@@ -4194,10 +4128,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Economica",
@@ -4211,10 +4145,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Eczar",
@@ -4230,10 +4164,10 @@
     "genericFamily": "serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "El+Messiri",
@@ -4247,11 +4181,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
+      "arabic",
       "cyrillic",
-      "arabic"
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Electrolize",
@@ -4264,7 +4198,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Elsie",
@@ -4276,10 +4210,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Elsie+Swash+Caps",
@@ -4291,10 +4225,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Emblema+One",
@@ -4305,10 +4239,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Emilys+Candy",
@@ -4319,10 +4253,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Encode+Sans",
@@ -4341,11 +4275,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Encode+Sans+Condensed",
@@ -4364,11 +4298,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Encode+Sans+Expanded",
@@ -4387,11 +4321,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Encode+Sans+Semi+Condensed",
@@ -4410,11 +4344,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Encode+Sans+Semi+Expanded",
@@ -4433,11 +4367,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Engagement",
@@ -4450,7 +4384,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Englebert",
@@ -4461,10 +4395,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Enriqueta",
@@ -4472,16 +4406,14 @@
     "displayName": "Enriqueta",
     "fvds": [
       "n4",
-      "n5",
-      "n6",
       "n7"
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Erica+One",
@@ -4492,10 +4424,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Esteban",
@@ -4506,10 +4438,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Euphoria+Script",
@@ -4520,10 +4452,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ewert",
@@ -4534,10 +4466,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Exo",
@@ -4565,11 +4497,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Exo+2",
@@ -4597,9 +4529,9 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
     "bodyText": true
   },
@@ -4621,7 +4553,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fahkwang",
@@ -4643,12 +4575,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fanwood+Text",
@@ -4662,24 +4594,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
-  },
-  {
-    "id": "Farro",
-    "cssName": "Farro",
-    "displayName": "Farro",
-    "fvds": [
-      "n3",
-      "n4",
-      "n5",
-      "n7"
-    ],
-    "genericFamily": "sans-serif",
-    "subsets": [
-      "latin",
-      "latin-ext"
-    ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Farsan",
@@ -4691,11 +4606,11 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "gujarati",
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fascinate",
@@ -4708,7 +4623,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fascinate+Inline",
@@ -4721,7 +4636,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Faster+One",
@@ -4734,7 +4649,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fasthand",
@@ -4747,7 +4662,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fauna+One",
@@ -4758,10 +4673,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Faustina",
@@ -4779,11 +4694,11 @@
     ],
     "genericFamily": "serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Federant",
@@ -4796,7 +4711,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Federo",
@@ -4809,7 +4724,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Felipa",
@@ -4820,10 +4735,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fenix",
@@ -4834,10 +4749,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Finger+Paint",
@@ -4850,29 +4765,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
-  },
-  {
-    "id": "Fira+Code",
-    "cssName": "Fira Code",
-    "displayName": "Fira Code",
-    "fvds": [
-      "n3",
-      "n4",
-      "n5",
-      "n6",
-      "n7"
-    ],
-    "genericFamily": "monospace",
-    "subsets": [
-      "greek",
-      "greek-ext",
-      "latin",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
-    ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fira+Mono",
@@ -4885,14 +4778,14 @@
     ],
     "genericFamily": "monospace",
     "subsets": [
-      "greek",
-      "greek-ext",
-      "latin",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fira+Sans",
@@ -4920,15 +4813,15 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fira+Sans+Condensed",
@@ -4956,15 +4849,15 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fira+Sans+Extra+Condensed",
@@ -4992,15 +4885,15 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fjalla+One",
@@ -5011,10 +4904,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fjord+One",
@@ -5027,7 +4920,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Flamenco",
@@ -5041,7 +4934,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Flavors",
@@ -5052,10 +4945,9 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fondamento",
@@ -5067,8 +4959,8 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
     "bodyText": false
   },
@@ -5083,7 +4975,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Forum",
@@ -5094,12 +4986,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Francois+One",
@@ -5110,11 +5002,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Frank+Ruhl+Libre",
@@ -5130,10 +5022,10 @@
     "genericFamily": "serif",
     "subsets": [
       "hebrew",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Freckle+Face",
@@ -5144,10 +5036,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fredericka+the+Great",
@@ -5158,10 +5050,9 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fredoka+One",
@@ -5174,7 +5065,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Freehand",
@@ -5187,7 +5078,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fresca",
@@ -5198,10 +5089,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Frijole",
@@ -5214,7 +5105,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fruktur",
@@ -5225,10 +5116,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Fugaz+One",
@@ -5241,7 +5132,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "GFS+Didot",
@@ -5254,7 +5145,7 @@
     "subsets": [
       "greek"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "GFS+Neohellenic",
@@ -5270,7 +5161,7 @@
     "subsets": [
       "greek"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Gabriela",
@@ -5281,11 +5172,11 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
       "cyrillic",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Gaegu",
@@ -5298,10 +5189,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Gafata",
@@ -5312,10 +5203,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Galada",
@@ -5326,10 +5217,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "bengali"
+      "bengali",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Galdeano",
@@ -5342,7 +5233,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Galindo",
@@ -5353,10 +5244,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Gamja+Flower",
@@ -5367,10 +5258,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Gentium+Basic",
@@ -5384,10 +5275,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Gentium+Book+Basic",
@@ -5401,8 +5292,8 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
     "bodyText": true
   },
@@ -5418,7 +5309,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Geostar",
@@ -5431,7 +5322,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Geostar+Fill",
@@ -5444,7 +5335,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Germania+One",
@@ -5457,7 +5348,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Gidugu",
@@ -5468,10 +5359,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "telugu"
+      "telugu",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Gilda+Display",
@@ -5482,10 +5373,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Give+You+Glory",
@@ -5498,7 +5389,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Glass+Antiqua",
@@ -5509,10 +5400,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Glegoo",
@@ -5525,10 +5416,10 @@
     "genericFamily": "serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Gloria+Hallelujah",
@@ -5541,7 +5432,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Goblin+One",
@@ -5554,7 +5445,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Gochi+Hand",
@@ -5567,7 +5458,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Gorditas",
@@ -5581,7 +5472,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Gothic+A1",
@@ -5600,10 +5491,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Goudy+Bookletter+1911",
@@ -5616,7 +5507,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Graduate",
@@ -5629,7 +5520,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Grand+Hotel",
@@ -5640,10 +5531,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Gravitas+One",
@@ -5656,7 +5547,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Great+Vibes",
@@ -5667,42 +5558,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
-  },
-  {
-    "id": "Grenze",
-    "cssName": "Grenze",
-    "displayName": "Grenze",
-    "fvds": [
-      "n1",
-      "i1",
-      "n2",
-      "i2",
-      "n3",
-      "i3",
-      "n4",
-      "i4",
-      "n5",
-      "i5",
-      "n6",
-      "i6",
-      "n7",
-      "i7",
-      "n8",
-      "i8",
-      "n9",
-      "i9"
-    ],
-    "genericFamily": "serif",
-    "subsets": [
-      "latin",
-      "vietnamese",
-      "latin-ext"
-    ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Griffy",
@@ -5713,10 +5572,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Gruppo",
@@ -5727,10 +5586,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Gudea",
@@ -5743,10 +5602,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Gugi",
@@ -5757,10 +5616,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Gurajada",
@@ -5771,10 +5630,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "telugu"
+      "telugu",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Habibi",
@@ -5785,10 +5644,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Halant",
@@ -5804,10 +5663,10 @@
     "genericFamily": "serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Hammersmith+One",
@@ -5818,10 +5677,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Hanalei",
@@ -5832,10 +5691,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Hanalei+Fill",
@@ -5846,10 +5705,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Handlee",
@@ -5862,7 +5721,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Hanuman",
@@ -5876,7 +5735,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Happy+Monkey",
@@ -5887,10 +5746,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Harmattan",
@@ -5901,10 +5760,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "arabic"
+      "arabic",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Headland+One",
@@ -5915,10 +5774,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Heebo",
@@ -5938,7 +5797,7 @@
       "hebrew",
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Henny+Penny",
@@ -5951,7 +5810,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Herr+Von+Muellerhoff",
@@ -5962,10 +5821,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Hi+Melody",
@@ -5976,10 +5835,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Hind",
@@ -5995,10 +5854,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Hind+Guntur",
@@ -6013,11 +5872,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
+      "latin-ext",
       "telugu",
-      "latin-ext"
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Hind+Madurai",
@@ -6032,11 +5891,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "tamil",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Hind+Siliguri",
@@ -6051,11 +5910,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "bengali",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Hind+Vadodara",
@@ -6071,10 +5930,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "gujarati",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Holtwood+One+SC",
@@ -6087,7 +5946,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Homemade+Apple",
@@ -6100,7 +5959,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Homenaje",
@@ -6113,7 +5972,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "IBM+Plex+Mono",
@@ -6137,13 +5996,13 @@
     ],
     "genericFamily": "monospace",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "IBM+Plex+Sans",
@@ -6167,14 +6026,14 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "greek",
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "IBM+Plex+Sans+Condensed",
@@ -6198,11 +6057,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "IBM+Plex+Serif",
@@ -6226,13 +6085,13 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "IM+Fell+DW+Pica",
@@ -6246,7 +6105,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "IM+Fell+DW+Pica+SC",
@@ -6259,7 +6118,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "IM+Fell+Double+Pica",
@@ -6273,7 +6132,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "IM+Fell+Double+Pica+SC",
@@ -6286,7 +6145,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "IM+Fell+English",
@@ -6300,7 +6159,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "IM+Fell+English+SC",
@@ -6313,7 +6172,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "IM+Fell+French+Canon",
@@ -6327,7 +6186,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "IM+Fell+French+Canon+SC",
@@ -6340,7 +6199,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "IM+Fell+Great+Primer",
@@ -6354,7 +6213,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "IM+Fell+Great+Primer+SC",
@@ -6367,7 +6226,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Iceberg",
@@ -6380,7 +6239,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Iceland",
@@ -6393,7 +6252,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Imprima",
@@ -6404,10 +6263,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Inconsolata",
@@ -6419,11 +6278,11 @@
     ],
     "genericFamily": "monospace",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Inder",
@@ -6434,10 +6293,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Indie+Flower",
@@ -6450,7 +6309,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Inika",
@@ -6462,10 +6321,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Inknut+Antiqua",
@@ -6483,10 +6342,10 @@
     "genericFamily": "serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Irish+Grover",
@@ -6499,7 +6358,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Istok+Web",
@@ -6513,12 +6372,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Italiana",
@@ -6531,7 +6390,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Italianno",
@@ -6542,10 +6401,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Itim",
@@ -6556,12 +6415,12 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Jacques+Francois",
@@ -6574,7 +6433,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Jacques+Francois+Shadow",
@@ -6587,7 +6446,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Jaldi",
@@ -6600,10 +6459,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Jim+Nightshade",
@@ -6614,10 +6473,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Jockey+One",
@@ -6628,10 +6487,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Jolly+Lodger",
@@ -6642,10 +6501,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Jomhuria",
@@ -6656,11 +6515,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
+      "arabic",
       "latin-ext",
-      "arabic"
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Josefin+Sans",
@@ -6680,11 +6539,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Josefin+Slab",
@@ -6706,7 +6565,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Joti+One",
@@ -6717,10 +6576,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Jua",
@@ -6731,10 +6590,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Judson",
@@ -6747,11 +6606,11 @@
     ],
     "genericFamily": "serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Julee",
@@ -6764,7 +6623,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Julius+Sans+One",
@@ -6775,10 +6634,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Junge",
@@ -6791,7 +6650,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Jura",
@@ -6806,15 +6665,15 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Just+Another+Hand",
@@ -6827,7 +6686,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Just+Me+Again+Down+Here",
@@ -6838,10 +6697,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "K2D",
@@ -6867,12 +6726,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kadwa",
@@ -6887,7 +6746,7 @@
       "devanagari",
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kalam",
@@ -6901,10 +6760,10 @@
     "genericFamily": "cursive",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kameron",
@@ -6918,7 +6777,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kanit",
@@ -6946,12 +6805,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kantumruy",
@@ -6966,7 +6825,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Karla",
@@ -6980,8 +6839,8 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
     "bodyText": true
   },
@@ -6999,10 +6858,10 @@
     "genericFamily": "serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Katibeh",
@@ -7013,11 +6872,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
+      "arabic",
       "latin-ext",
-      "arabic"
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kaushan+Script",
@@ -7028,10 +6887,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kavivanar",
@@ -7042,11 +6901,11 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
       "tamil",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kavoon",
@@ -7057,10 +6916,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kdam+Thmor",
@@ -7073,7 +6932,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Keania+One",
@@ -7084,10 +6943,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kelly+Slab",
@@ -7098,11 +6957,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kenia",
@@ -7115,7 +6974,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Khand",
@@ -7131,10 +6990,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Khmer",
@@ -7147,7 +7006,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Khula",
@@ -7163,10 +7022,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kirang+Haerang",
@@ -7177,10 +7036,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kite+One",
@@ -7193,7 +7052,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Knewave",
@@ -7204,10 +7063,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "KoHo",
@@ -7229,12 +7088,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kodchasan",
@@ -7256,12 +7115,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kosugi",
@@ -7272,11 +7131,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "japanese",
+      "cyrillic",
       "latin",
-      "cyrillic"
+      "japanese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kosugi+Maru",
@@ -7287,11 +7146,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "japanese",
+      "cyrillic",
       "latin",
-      "cyrillic"
+      "japanese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kotta+One",
@@ -7302,10 +7161,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Koulen",
@@ -7318,7 +7177,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kranky",
@@ -7331,7 +7190,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kreon",
@@ -7340,16 +7199,13 @@
     "fvds": [
       "n3",
       "n4",
-      "n5",
-      "n6",
       "n7"
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kristi",
@@ -7362,7 +7218,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Krona+One",
@@ -7373,10 +7229,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Krub",
@@ -7398,12 +7254,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kumar+One",
@@ -7415,10 +7271,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "gujarati",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kumar+One+Outline",
@@ -7430,10 +7286,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "gujarati",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Kurale",
@@ -7444,13 +7300,13 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "devanagari",
-      "latin",
       "cyrillic",
+      "devanagari",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "La+Belle+Aurore",
@@ -7463,20 +7319,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
-  },
-  {
-    "id": "Lacquer",
-    "cssName": "Lacquer",
-    "displayName": "Lacquer",
-    "fvds": [
-      "n4"
-    ],
-    "genericFamily": "sans-serif",
-    "subsets": [
-      "latin"
-    ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Laila",
@@ -7492,10 +7335,10 @@
     "genericFamily": "serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Lakki+Reddy",
@@ -7506,10 +7349,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "telugu"
+      "telugu",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Lalezar",
@@ -7520,12 +7363,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
+      "arabic",
       "latin-ext",
-      "arabic"
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Lancelot",
@@ -7536,10 +7379,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Lateef",
@@ -7550,10 +7393,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "arabic"
+      "arabic",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Lato",
@@ -7573,8 +7416,8 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
     "bodyText": true
   },
@@ -7589,7 +7432,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Leckerli+One",
@@ -7602,7 +7445,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ledger",
@@ -7613,11 +7456,11 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Lekton",
@@ -7630,10 +7473,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Lemon",
@@ -7646,7 +7489,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Lemonada",
@@ -7660,12 +7503,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
+      "arabic",
       "latin-ext",
-      "arabic"
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Libre+Barcode+128",
@@ -7678,7 +7521,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Libre+Barcode+128+Text",
@@ -7691,7 +7534,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Libre+Barcode+39",
@@ -7704,7 +7547,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Libre+Barcode+39+Extended",
@@ -7717,7 +7560,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Libre+Barcode+39+Extended+Text",
@@ -7730,7 +7573,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Libre+Barcode+39+Text",
@@ -7743,7 +7586,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Libre+Baskerville",
@@ -7756,40 +7599,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
     "bodyText": true
-  },
-  {
-    "id": "Libre+Caslon+Display",
-    "cssName": "Libre Caslon Display",
-    "displayName": "Libre Caslon Display",
-    "fvds": [
-      "n4"
-    ],
-    "genericFamily": "serif",
-    "subsets": [
-      "latin",
-      "latin-ext"
-    ],
-    "bodyText": false
-  },
-  {
-    "id": "Libre+Caslon+Text",
-    "cssName": "Libre Caslon Text",
-    "displayName": "Libre Caslon Text",
-    "fvds": [
-      "n4",
-      "i4",
-      "n7"
-    ],
-    "genericFamily": "serif",
-    "subsets": [
-      "latin",
-      "latin-ext"
-    ],
-    "bodyText": false
   },
   {
     "id": "Libre+Franklin",
@@ -7817,10 +7630,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Life+Savers",
@@ -7833,10 +7646,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Lilita+One",
@@ -7847,10 +7660,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Lily+Script+One",
@@ -7861,10 +7674,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Limelight",
@@ -7875,10 +7688,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Linden+Hill",
@@ -7892,7 +7705,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Literata",
@@ -7910,28 +7723,14 @@
     ],
     "genericFamily": "serif",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
-  },
-  {
-    "id": "Liu+Jian+Mao+Cao",
-    "cssName": "Liu Jian Mao Cao",
-    "displayName": "Liu Jian Mao Cao",
-    "fvds": [
-      "n4"
-    ],
-    "genericFamily": "cursive",
-    "subsets": [
-      "chinese-simplified",
-      "latin"
-    ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Lobster",
@@ -7942,13 +7741,13 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Lobster+Two",
@@ -7977,7 +7776,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Londrina+Shadow",
@@ -7990,7 +7789,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Londrina+Sketch",
@@ -8003,7 +7802,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Londrina+Solid",
@@ -8019,21 +7818,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
-  },
-  {
-    "id": "Long+Cang",
-    "cssName": "Long Cang",
-    "displayName": "Long Cang",
-    "fvds": [
-      "n4"
-    ],
-    "genericFamily": "cursive",
-    "subsets": [
-      "chinese-simplified",
-      "latin"
-    ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Lora",
@@ -8047,11 +7832,11 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
     "bodyText": true
   },
@@ -8066,7 +7851,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Loved+by+the+King",
@@ -8079,7 +7864,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Lovers+Quarrel",
@@ -8090,10 +7875,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Luckiest+Guy",
@@ -8106,7 +7891,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Lusitana",
@@ -8120,7 +7905,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Lustria",
@@ -8133,7 +7918,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "M+PLUS+1p",
@@ -8150,17 +7935,17 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "cyrillic",
       "hebrew",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
-      "japanese",
       "greek-ext",
       "latin",
       "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "japanese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "M+PLUS+Rounded+1c",
@@ -8177,31 +7962,17 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "cyrillic",
       "hebrew",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
-      "japanese",
       "greek-ext",
       "latin",
       "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "japanese"
     ],
-    "bodyText": false
-  },
-  {
-    "id": "Ma+Shan+Zheng",
-    "cssName": "Ma Shan Zheng",
-    "displayName": "Ma Shan Zheng",
-    "fvds": [
-      "n4"
-    ],
-    "genericFamily": "cursive",
-    "subsets": [
-      "chinese-simplified",
-      "latin"
-    ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Macondo",
@@ -8214,7 +7985,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Macondo+Swash+Caps",
@@ -8227,7 +7998,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mada",
@@ -8244,10 +8015,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "arabic"
+      "arabic",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Magra",
@@ -8259,10 +8030,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Maiden+Orange",
@@ -8275,7 +8046,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Maitree",
@@ -8291,12 +8062,12 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Major+Mono+Display",
@@ -8307,11 +8078,11 @@
     ],
     "genericFamily": "monospace",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mako",
@@ -8324,7 +8095,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mali",
@@ -8346,12 +8117,12 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mallanna",
@@ -8362,10 +8133,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "telugu"
+      "telugu",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mandali",
@@ -8376,10 +8147,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "telugu"
+      "telugu",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Manuale",
@@ -8397,11 +8168,11 @@
     ],
     "genericFamily": "serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Marcellus",
@@ -8412,10 +8183,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Marcellus+SC",
@@ -8426,10 +8197,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Marck+Script",
@@ -8440,11 +8211,11 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Margarine",
@@ -8455,10 +8226,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Markazi+Text",
@@ -8472,12 +8243,12 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
+      "arabic",
       "latin-ext",
-      "arabic"
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Marko+One",
@@ -8490,7 +8261,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Marmelad",
@@ -8501,11 +8272,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Martel",
@@ -8523,10 +8294,10 @@
     "genericFamily": "serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Martel+Sans",
@@ -8544,10 +8315,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Marvel",
@@ -8563,7 +8334,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mate",
@@ -8577,7 +8348,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mate+SC",
@@ -8590,7 +8361,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Maven+Pro",
@@ -8604,11 +8375,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "McLaren",
@@ -8619,10 +8390,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Meddon",
@@ -8635,7 +8406,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "MedievalSharp",
@@ -8646,10 +8417,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Medula+One",
@@ -8662,7 +8433,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Meera+Inimai",
@@ -8673,10 +8444,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "tamil"
+      "tamil",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Megrim",
@@ -8689,7 +8460,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Meie+Script",
@@ -8700,10 +8471,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Merienda",
@@ -8715,10 +8486,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Merienda+One",
@@ -8731,7 +8502,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Merriweather",
@@ -8749,11 +8520,11 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
     "bodyText": true
   },
@@ -8773,8 +8544,8 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
     "bodyText": true
   },
@@ -8789,7 +8560,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Metal+Mania",
@@ -8800,10 +8571,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Metamorphous",
@@ -8814,10 +8585,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Metrophobic",
@@ -8828,11 +8599,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Michroma",
@@ -8845,7 +8616,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Milonga",
@@ -8856,10 +8627,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Miltonian",
@@ -8872,7 +8643,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Miltonian+Tattoo",
@@ -8885,7 +8656,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mina",
@@ -8897,11 +8668,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "bengali",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Miniver",
@@ -8914,7 +8685,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Miriam+Libre",
@@ -8927,10 +8698,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "hebrew",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mirza",
@@ -8944,11 +8715,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
+      "arabic",
       "latin-ext",
-      "arabic"
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Miss+Fajardose",
@@ -8959,10 +8730,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mitr",
@@ -8978,12 +8749,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Modak",
@@ -8995,10 +8766,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Modern+Antiqua",
@@ -9009,10 +8780,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mogra",
@@ -9024,10 +8795,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "gujarati",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Molengo",
@@ -9038,10 +8809,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Molle",
@@ -9052,10 +8823,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Monda",
@@ -9067,10 +8838,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Monofett",
@@ -9083,7 +8854,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Monoton",
@@ -9096,7 +8867,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Monsieur+La+Doulaise",
@@ -9107,10 +8878,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Montaga",
@@ -9123,7 +8894,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Montez",
@@ -9136,7 +8907,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Montserrat",
@@ -9164,11 +8935,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
     "bodyText": false
   },
@@ -9198,13 +8969,13 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Montserrat+Subrayada",
@@ -9218,7 +8989,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Moul",
@@ -9231,7 +9002,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Moulpali",
@@ -9244,7 +9015,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mountains+of+Christmas",
@@ -9258,7 +9029,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mouse+Memoirs",
@@ -9269,10 +9040,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mr+Bedfort",
@@ -9283,10 +9054,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mr+Dafoe",
@@ -9297,10 +9068,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mr+De+Haviland",
@@ -9311,10 +9082,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mrs+Saint+Delafield",
@@ -9325,10 +9096,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mrs+Sheppards",
@@ -9339,10 +9110,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mukta",
@@ -9360,10 +9131,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mukta+Mahee",
@@ -9381,10 +9152,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "gurmukhi",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mukta+Malar",
@@ -9401,11 +9172,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "tamil",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Mukta+Vaani",
@@ -9423,10 +9194,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "gujarati",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Muli",
@@ -9450,9 +9221,9 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
     "bodyText": false
   },
@@ -9465,10 +9236,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "NTR",
@@ -9479,10 +9250,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "telugu"
+      "telugu",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nanum+Brush+Script",
@@ -9493,10 +9264,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nanum+Gothic",
@@ -9509,10 +9280,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nanum+Gothic+Coding",
@@ -9524,10 +9295,10 @@
     ],
     "genericFamily": "monospace",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nanum+Myeongjo",
@@ -9540,10 +9311,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nanum+Pen+Script",
@@ -9554,10 +9325,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Neucha",
@@ -9568,10 +9339,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "cyrillic"
+      "cyrillic",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Neuton",
@@ -9587,10 +9358,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "New+Rocker",
@@ -9601,10 +9372,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "News+Cycle",
@@ -9616,10 +9387,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Niconne",
@@ -9630,10 +9401,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Niramit",
@@ -9655,12 +9426,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nixie+One",
@@ -9673,7 +9444,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nobile",
@@ -9689,10 +9460,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nokora",
@@ -9706,7 +9477,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Norican",
@@ -9717,10 +9488,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nosifer",
@@ -9731,10 +9502,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Notable",
@@ -9747,7 +9518,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nothing+You+Could+Do",
@@ -9760,7 +9531,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Noticia+Text",
@@ -9774,9 +9545,9 @@
     ],
     "genericFamily": "serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
     "bodyText": true
   },
@@ -9792,14 +9563,14 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "cyrillic",
       "devanagari",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
     "bodyText": true
   },
@@ -9820,7 +9591,7 @@
       "chinese-hongkong",
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Noto+Sans+JP",
@@ -9836,10 +9607,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "japanese",
-      "latin"
+      "latin",
+      "japanese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Noto+Sans+KR",
@@ -9855,10 +9626,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Noto+Sans+SC",
@@ -9874,12 +9645,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "cyrillic",
       "chinese-simplified",
       "latin",
-      "vietnamese",
-      "cyrillic"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Noto+Sans+TC",
@@ -9895,10 +9666,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "chinese-traditional"
+      "chinese-traditional",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Noto+Serif",
@@ -9912,13 +9683,13 @@
     ],
     "genericFamily": "serif",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
     "bodyText": true
   },
@@ -9937,10 +9708,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "japanese",
-      "latin"
+      "latin",
+      "japanese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Noto+Serif+KR",
@@ -9957,10 +9728,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Noto+Serif+SC",
@@ -9977,12 +9748,12 @@
     ],
     "genericFamily": "serif",
     "subsets": [
+      "cyrillic",
       "chinese-simplified",
       "latin",
-      "vietnamese",
-      "cyrillic"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Noto+Serif+TC",
@@ -9999,12 +9770,12 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
-      "chinese-traditional"
+      "chinese-traditional",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nova+Cut",
@@ -10017,7 +9788,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nova+Flat",
@@ -10030,7 +9801,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nova+Mono",
@@ -10044,7 +9815,7 @@
       "greek",
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nova+Oval",
@@ -10057,7 +9828,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nova+Round",
@@ -10070,7 +9841,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nova+Script",
@@ -10083,7 +9854,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nova+Slim",
@@ -10096,7 +9867,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nova+Square",
@@ -10109,7 +9880,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Numans",
@@ -10122,7 +9893,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nunito",
@@ -10146,11 +9917,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Nunito+Sans",
@@ -10174,11 +9945,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Odor+Mean+Chey",
@@ -10191,7 +9962,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Offside",
@@ -10204,7 +9975,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Old+Standard+TT",
@@ -10217,13 +9988,13 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Oldenburg",
@@ -10234,10 +10005,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Oleo+Script",
@@ -10249,10 +10020,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Oleo+Script+Swash+Caps",
@@ -10264,10 +10035,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Open+Sans",
@@ -10287,13 +10058,13 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
     "bodyText": true
   },
@@ -10308,15 +10079,15 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Oranienbaum",
@@ -10327,12 +10098,12 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Orbitron",
@@ -10348,7 +10119,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Oregano",
@@ -10360,10 +10131,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Orienta",
@@ -10374,10 +10145,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Original+Surfer",
@@ -10390,7 +10161,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Oswald",
@@ -10406,11 +10177,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
     "bodyText": false
   },
@@ -10425,7 +10196,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Overlock",
@@ -10441,10 +10212,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Overlock+SC",
@@ -10455,10 +10226,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Overpass",
@@ -10484,10 +10255,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Overpass+Mono",
@@ -10501,10 +10272,10 @@
     ],
     "genericFamily": "monospace",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ovo",
@@ -10517,7 +10288,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Oxygen",
@@ -10530,10 +10301,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Oxygen+Mono",
@@ -10544,10 +10315,10 @@
     ],
     "genericFamily": "monospace",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "PT+Mono",
@@ -10558,12 +10329,12 @@
     ],
     "genericFamily": "monospace",
     "subsets": [
-      "latin",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "PT+Sans",
@@ -10577,10 +10348,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin"
     ],
     "bodyText": true
   },
@@ -10594,12 +10365,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "PT+Sans+Narrow",
@@ -10611,12 +10382,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "PT+Serif",
@@ -10630,10 +10401,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin"
     ],
     "bodyText": true
   },
@@ -10647,12 +10418,12 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Pacifico",
@@ -10663,13 +10434,13 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Padauk",
@@ -10681,10 +10452,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "myanmar"
+      "myanmar",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Palanquin",
@@ -10702,10 +10473,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Palanquin+Dark",
@@ -10720,10 +10491,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Pangolin",
@@ -10734,13 +10505,13 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Paprika",
@@ -10753,7 +10524,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Parisienne",
@@ -10764,10 +10535,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Passero+One",
@@ -10778,10 +10549,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Passion+One",
@@ -10794,10 +10565,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Pathway+Gothic+One",
@@ -10808,10 +10579,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Patrick+Hand",
@@ -10822,11 +10593,11 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Patrick+Hand+SC",
@@ -10837,11 +10608,11 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Pattaya",
@@ -10852,13 +10623,13 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
-      "thai",
       "cyrillic",
-      "latin-ext"
+      "thai",
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Patua+One",
@@ -10871,7 +10642,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Pavanam",
@@ -10882,11 +10653,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "tamil",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Paytone+One",
@@ -10897,11 +10668,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Peddana",
@@ -10912,10 +10683,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "telugu"
+      "telugu",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Peralta",
@@ -10926,10 +10697,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Permanent+Marker",
@@ -10942,7 +10713,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Petit+Formal+Script",
@@ -10953,10 +10724,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Petrona",
@@ -10969,7 +10740,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Philosopher",
@@ -10983,12 +10754,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Piedra",
@@ -10999,10 +10770,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Pinyon+Script",
@@ -11015,7 +10786,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Pirata+One",
@@ -11026,10 +10797,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Plaster",
@@ -11040,10 +10811,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Play",
@@ -11055,14 +10826,14 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "greek",
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Playball",
@@ -11073,10 +10844,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Playfair+Display",
@@ -11092,10 +10863,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
     "bodyText": false
   },
@@ -11113,12 +10884,12 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Podkova",
@@ -11133,13 +10904,13 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Poiret+One",
@@ -11150,11 +10921,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Poller+One",
@@ -11167,7 +10938,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Poly",
@@ -11181,7 +10952,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Pompiere",
@@ -11194,7 +10965,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Pontano+Sans",
@@ -11205,10 +10976,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Poor+Story",
@@ -11219,10 +10990,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Poppins",
@@ -11251,10 +11022,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Port+Lligat+Sans",
@@ -11267,7 +11038,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Port+Lligat+Slab",
@@ -11280,7 +11051,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Pragati+Narrow",
@@ -11293,10 +11064,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Prata",
@@ -11307,12 +11078,12 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Preahvihear",
@@ -11325,7 +11096,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Press+Start+2P",
@@ -11336,13 +11107,13 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "greek",
-      "latin",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "greek",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Pridi",
@@ -11358,12 +11129,12 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Princess+Sofia",
@@ -11374,10 +11145,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Prociono",
@@ -11390,7 +11161,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Prompt",
@@ -11418,12 +11189,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Prosto+One",
@@ -11434,11 +11205,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Proza+Libre",
@@ -11458,10 +11229,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Puritan",
@@ -11477,7 +11248,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Purple+Purse",
@@ -11488,10 +11259,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Quando",
@@ -11502,10 +11273,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Quantico",
@@ -11521,7 +11292,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Quattrocento",
@@ -11533,10 +11304,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Quattrocento+Sans",
@@ -11550,8 +11321,8 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
     "bodyText": true
   },
@@ -11566,7 +11337,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Quicksand",
@@ -11576,16 +11347,15 @@
       "n3",
       "n4",
       "n5",
-      "n6",
       "n7"
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Quintessential",
@@ -11596,10 +11366,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Qwigley",
@@ -11610,10 +11380,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Racing+Sans+One",
@@ -11624,10 +11394,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Radley",
@@ -11639,10 +11409,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rajdhani",
@@ -11658,10 +11428,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rakkas",
@@ -11672,11 +11442,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
+      "arabic",
       "latin-ext",
-      "arabic"
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Raleway",
@@ -11704,10 +11474,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Raleway+Dots",
@@ -11718,10 +11488,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ramabhadra",
@@ -11732,10 +11502,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "telugu"
+      "telugu",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ramaraja",
@@ -11746,10 +11516,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "telugu"
+      "telugu",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rambla",
@@ -11763,10 +11533,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rammetto+One",
@@ -11777,10 +11547,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ranchers",
@@ -11791,10 +11561,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rancho",
@@ -11807,7 +11577,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ranga",
@@ -11820,10 +11590,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rasa",
@@ -11839,10 +11609,10 @@
     "genericFamily": "serif",
     "subsets": [
       "gujarati",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rationale",
@@ -11855,7 +11625,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ravi+Prakash",
@@ -11866,50 +11636,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "telugu"
+      "telugu",
+      "latin"
     ],
-    "bodyText": false
-  },
-  {
-    "id": "Red+Hat+Display",
-    "cssName": "Red Hat Display",
-    "displayName": "Red Hat Display",
-    "fvds": [
-      "n4",
-      "i4",
-      "n5",
-      "i5",
-      "n7",
-      "i7",
-      "n9",
-      "i9"
-    ],
-    "genericFamily": "sans-serif",
-    "subsets": [
-      "latin",
-      "latin-ext"
-    ],
-    "bodyText": false
-  },
-  {
-    "id": "Red+Hat+Text",
-    "cssName": "Red Hat Text",
-    "displayName": "Red Hat Text",
-    "fvds": [
-      "n4",
-      "i4",
-      "n5",
-      "i5",
-      "n7",
-      "i7"
-    ],
-    "genericFamily": "sans-serif",
-    "subsets": [
-      "latin",
-      "latin-ext"
-    ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Redressed",
@@ -11922,7 +11652,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Reem+Kufi",
@@ -11933,10 +11663,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "arabic"
+      "arabic",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Reenie+Beanie",
@@ -11949,7 +11679,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Revalia",
@@ -11960,10 +11690,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rhodium+Libre",
@@ -11975,10 +11705,10 @@
     "genericFamily": "serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ribeye",
@@ -11989,10 +11719,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ribeye+Marrow",
@@ -12003,10 +11733,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Righteous",
@@ -12017,10 +11747,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Risque",
@@ -12031,10 +11761,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Roboto",
@@ -12056,15 +11786,15 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Roboto+Condensed",
@@ -12080,15 +11810,15 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Roboto+Mono",
@@ -12108,15 +11838,15 @@
     ],
     "genericFamily": "monospace",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Roboto+Slab",
@@ -12130,13 +11860,13 @@
     ],
     "genericFamily": "serif",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
     "bodyText": false
   },
@@ -12151,7 +11881,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rock+Salt",
@@ -12164,7 +11894,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rokkitt",
@@ -12183,11 +11913,11 @@
     ],
     "genericFamily": "serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Romanesco",
@@ -12198,10 +11928,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ropa+Sans",
@@ -12213,10 +11943,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rosario",
@@ -12232,7 +11962,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rosarivo",
@@ -12244,10 +11974,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rouge+Script",
@@ -12260,7 +11990,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rozha+One",
@@ -12272,10 +12002,10 @@
     "genericFamily": "serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rubik",
@@ -12295,12 +12025,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "hebrew",
-      "latin",
       "cyrillic",
-      "latin-ext"
+      "hebrew",
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rubik+Mono+One",
@@ -12311,11 +12041,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ruda",
@@ -12328,10 +12058,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rufina",
@@ -12343,10 +12073,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ruge+Boogie",
@@ -12357,10 +12087,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ruluko",
@@ -12371,10 +12101,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rum+Raisin",
@@ -12385,10 +12115,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ruslan+Display",
@@ -12399,11 +12129,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Russo+One",
@@ -12414,11 +12144,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ruthie",
@@ -12429,10 +12159,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Rye",
@@ -12443,10 +12173,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sacramento",
@@ -12457,10 +12187,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sahitya",
@@ -12475,7 +12205,7 @@
       "devanagari",
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sail",
@@ -12486,10 +12216,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Saira",
@@ -12508,11 +12238,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Saira+Condensed",
@@ -12531,11 +12261,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Saira+Extra+Condensed",
@@ -12554,11 +12284,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Saira+Semi+Condensed",
@@ -12577,26 +12307,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
-  },
-  {
-    "id": "Saira+Stencil+One",
-    "cssName": "Saira Stencil One",
-    "displayName": "Saira Stencil One",
-    "fvds": [
-      "n4"
-    ],
-    "genericFamily": "sans-serif",
-    "subsets": [
-      "latin",
-      "vietnamese",
-      "latin-ext"
-    ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Salsa",
@@ -12609,7 +12324,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sanchez",
@@ -12621,10 +12336,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sancreek",
@@ -12635,10 +12350,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sansita",
@@ -12656,10 +12371,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sarabun",
@@ -12685,12 +12400,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sarala",
@@ -12703,10 +12418,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sarina",
@@ -12717,10 +12432,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sarpanch",
@@ -12737,10 +12452,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Satisfy",
@@ -12753,7 +12468,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sawarabi+Gothic",
@@ -12764,13 +12479,13 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "japanese",
+      "cyrillic",
+      "latin-ext",
       "latin",
       "vietnamese",
-      "cyrillic",
-      "latin-ext"
+      "japanese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sawarabi+Mincho",
@@ -12781,11 +12496,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "japanese",
+      "latin-ext",
       "latin",
-      "latin-ext"
+      "japanese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Scada",
@@ -12799,12 +12514,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Scheherazade",
@@ -12816,10 +12531,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "arabic"
+      "arabic",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Schoolbell",
@@ -12832,7 +12547,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Scope+One",
@@ -12843,10 +12558,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Seaweed+Script",
@@ -12857,10 +12572,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Secular+One",
@@ -12872,10 +12587,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "hebrew",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sedgwick+Ave",
@@ -12886,11 +12601,11 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sedgwick+Ave+Display",
@@ -12901,11 +12616,11 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sevillana",
@@ -12916,10 +12631,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Seymour+One",
@@ -12930,11 +12645,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Shadows+Into+Light",
@@ -12947,7 +12662,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Shadows+Into+Light+Two",
@@ -12958,10 +12673,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Shanti",
@@ -12974,7 +12689,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Share",
@@ -12988,10 +12703,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Share+Tech",
@@ -13004,7 +12719,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Share+Tech+Mono",
@@ -13017,7 +12732,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Shojumaru",
@@ -13028,10 +12743,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Short+Stack",
@@ -13044,7 +12759,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Shrikhand",
@@ -13056,10 +12771,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "gujarati",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Siemreap",
@@ -13072,7 +12787,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sigmar+One",
@@ -13083,11 +12798,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Signika",
@@ -13101,10 +12816,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Signika+Negative",
@@ -13118,10 +12833,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Simonetta",
@@ -13135,23 +12850,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
-  },
-  {
-    "id": "Single+Day",
-    "cssName": "Single Day",
-    "displayName": "Single Day",
-    "fvds": [
-      "n4"
-    ],
-    "genericFamily": "sans-serif",
-    "subsets": [
-      "korean"
-    ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sintony",
@@ -13163,10 +12865,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sirin+Stencil",
@@ -13179,7 +12881,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Six+Caps",
@@ -13192,7 +12894,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Skranji",
@@ -13204,10 +12906,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Slabo+13px",
@@ -13218,10 +12920,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Slabo+27px",
@@ -13232,10 +12934,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Slackey",
@@ -13248,7 +12950,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Smokum",
@@ -13261,7 +12963,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Smythe",
@@ -13274,7 +12976,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sniglet",
@@ -13286,10 +12988,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Snippet",
@@ -13302,7 +13004,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Snowburst+One",
@@ -13313,10 +13015,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sofadi+One",
@@ -13329,7 +13031,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sofia",
@@ -13342,7 +13044,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Song+Myung",
@@ -13353,10 +13055,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sonsie+One",
@@ -13367,10 +13069,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sorts+Mill+Goudy",
@@ -13382,10 +13084,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Source+Code+Pro",
@@ -13402,8 +13104,8 @@
     ],
     "genericFamily": "monospace",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
     "bodyText": true
   },
@@ -13427,13 +13129,13 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
+      "cyrillic",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
     "bodyText": true
   },
@@ -13448,10 +13150,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Space+Mono",
@@ -13465,11 +13167,11 @@
     ],
     "genericFamily": "monospace",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Special+Elite",
@@ -13482,7 +13184,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Spectral",
@@ -13506,12 +13208,12 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Spectral+SC",
@@ -13535,12 +13237,12 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Spicy+Rice",
@@ -13553,7 +13255,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Spinnaker",
@@ -13564,10 +13266,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Spirax",
@@ -13580,7 +13282,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Squada+One",
@@ -13593,7 +13295,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sree+Krushnadevaraya",
@@ -13604,10 +13306,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "telugu"
+      "telugu",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sriracha",
@@ -13618,12 +13320,12 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Srisakdi",
@@ -13635,12 +13337,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Staatliches",
@@ -13651,10 +13353,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Stalemate",
@@ -13665,10 +13367,10 @@
     ],
     "genericFamily": "cursive",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Stalinist+One",
@@ -13679,11 +13381,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Stardos+Stencil",
@@ -13697,7 +13399,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Stint+Ultra+Condensed",
@@ -13708,10 +13410,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Stint+Ultra+Expanded",
@@ -13722,10 +13424,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Stoke",
@@ -13737,10 +13439,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Strait",
@@ -13753,7 +13455,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Stylish",
@@ -13764,10 +13466,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sue+Ellen+Francisco",
@@ -13780,7 +13482,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Suez+One",
@@ -13792,10 +13494,10 @@
     "genericFamily": "serif",
     "subsets": [
       "hebrew",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sumana",
@@ -13808,10 +13510,10 @@
     "genericFamily": "serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sunflower",
@@ -13824,10 +13526,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sunshiney",
@@ -13840,7 +13542,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Supermercado+One",
@@ -13853,7 +13555,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Sura",
@@ -13866,10 +13568,10 @@
     "genericFamily": "serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Suranna",
@@ -13880,10 +13582,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "telugu"
+      "telugu",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Suravaram",
@@ -13894,10 +13596,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "telugu"
+      "telugu",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Suwannaphum",
@@ -13910,7 +13612,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Swanky+and+Moo+Moo",
@@ -13923,7 +13625,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Syncopate",
@@ -13937,7 +13639,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Tajawal",
@@ -13954,10 +13656,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "arabic"
+      "arabic",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Tangerine",
@@ -13984,7 +13686,7 @@
     "subsets": [
       "khmer"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Tauri",
@@ -13995,10 +13697,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Taviraj",
@@ -14026,12 +13728,12 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Teko",
@@ -14047,10 +13749,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Telex",
@@ -14061,10 +13763,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Tenali+Ramakrishna",
@@ -14075,10 +13777,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "telugu"
+      "telugu",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Tenor+Sans",
@@ -14089,11 +13791,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Text+Me+One",
@@ -14104,10 +13806,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Thasadith",
@@ -14121,12 +13823,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "The+Girl+Next+Door",
@@ -14139,7 +13841,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Tienne",
@@ -14154,7 +13856,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Tillana",
@@ -14170,10 +13872,10 @@
     "genericFamily": "cursive",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Timmana",
@@ -14184,10 +13886,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "telugu"
+      "telugu",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Tinos",
@@ -14201,16 +13903,16 @@
     ],
     "genericFamily": "serif",
     "subsets": [
+      "cyrillic",
       "hebrew",
+      "latin-ext",
+      "cyrillic-ext",
       "greek",
       "greek-ext",
       "latin",
-      "vietnamese",
-      "cyrillic",
-      "latin-ext",
-      "cyrillic-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Titan+One",
@@ -14221,10 +13923,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Titillium+Web",
@@ -14245,10 +13947,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Trade+Winds",
@@ -14261,7 +13963,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Trirong",
@@ -14289,12 +13991,12 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "thai",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Trocchi",
@@ -14305,10 +14007,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Trochut",
@@ -14323,7 +14025,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Trykker",
@@ -14334,10 +14036,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Tulpen+One",
@@ -14350,7 +14052,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ubuntu",
@@ -14368,12 +14070,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "greek",
-      "greek-ext",
-      "latin",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin"
     ],
     "bodyText": true
   },
@@ -14386,14 +14088,14 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "greek",
-      "greek-ext",
-      "latin",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ubuntu+Mono",
@@ -14407,14 +14109,14 @@
     ],
     "genericFamily": "monospace",
     "subsets": [
-      "greek",
-      "greek-ext",
-      "latin",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "greek",
+      "greek-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Ultra",
@@ -14427,7 +14129,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Uncial+Antiqua",
@@ -14440,7 +14142,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Underdog",
@@ -14451,11 +14153,11 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Unica+One",
@@ -14466,10 +14168,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "UnifrakturCook",
@@ -14482,7 +14184,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "UnifrakturMaguntia",
@@ -14495,7 +14197,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Unkempt",
@@ -14509,7 +14211,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Unlock",
@@ -14522,7 +14224,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Unna",
@@ -14536,10 +14238,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "VT323",
@@ -14550,11 +14252,11 @@
     ],
     "genericFamily": "monospace",
     "subsets": [
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Vampiro+One",
@@ -14565,10 +14267,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Varela",
@@ -14579,10 +14281,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Varela+Round",
@@ -14594,11 +14296,11 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "hebrew",
+      "latin-ext",
       "latin",
-      "vietnamese",
-      "latin-ext"
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Vast+Shadow",
@@ -14611,7 +14313,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Vesper+Libre",
@@ -14626,10 +14328,10 @@
     "genericFamily": "serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Vibur",
@@ -14642,7 +14344,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Vidaloka",
@@ -14655,7 +14357,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Viga",
@@ -14666,10 +14368,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Voces",
@@ -14680,10 +14382,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Volkhov",
@@ -14699,7 +14401,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Vollkorn",
@@ -14717,12 +14419,12 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "greek",
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "greek",
+      "latin",
+      "vietnamese"
     ],
     "bodyText": true
   },
@@ -14738,13 +14440,13 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Voltaire",
@@ -14757,7 +14459,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Waiting+for+the+Sunrise",
@@ -14770,7 +14472,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Wallpoet",
@@ -14783,7 +14485,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Walter+Turncoat",
@@ -14796,7 +14498,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Warnes",
@@ -14807,10 +14509,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Wellfleet",
@@ -14821,10 +14523,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Wendy+One",
@@ -14835,10 +14537,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Wire+One",
@@ -14851,7 +14553,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Work+Sans",
@@ -14870,10 +14572,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Yanone+Kaffeesatz",
@@ -14887,12 +14589,12 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
-      "latin-ext"
+      "latin-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Yantramanav",
@@ -14909,10 +14611,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Yatra+One",
@@ -14924,10 +14626,10 @@
     "genericFamily": "sans-serif",
     "subsets": [
       "devanagari",
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Yellowtail",
@@ -14940,7 +14642,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Yeon+Sung",
@@ -14951,10 +14653,10 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "korean"
+      "korean",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Yeseva+One",
@@ -14965,13 +14667,13 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "vietnamese",
       "cyrillic",
       "latin-ext",
-      "cyrillic-ext"
+      "cyrillic-ext",
+      "latin",
+      "vietnamese"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Yesteryear",
@@ -14984,7 +14686,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Yrsa",
@@ -14999,10 +14701,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "ZCOOL+KuaiLe",
@@ -15016,7 +14718,7 @@
       "chinese-simplified",
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "ZCOOL+QingKe+HuangYou",
@@ -15030,7 +14732,7 @@
       "chinese-simplified",
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "ZCOOL+XiaoWei",
@@ -15044,7 +14746,7 @@
       "chinese-simplified",
       "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Zeyada",
@@ -15057,21 +14759,7 @@
     "subsets": [
       "latin"
     ],
-    "bodyText": false
-  },
-  {
-    "id": "Zhi+Mang+Xing",
-    "cssName": "Zhi Mang Xing",
-    "displayName": "Zhi Mang Xing",
-    "fvds": [
-      "n4"
-    ],
-    "genericFamily": "cursive",
-    "subsets": [
-      "chinese-simplified",
-      "latin"
-    ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Zilla+Slab",
@@ -15091,10 +14779,10 @@
     ],
     "genericFamily": "serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   },
   {
     "id": "Zilla+Slab+Highlight",
@@ -15106,9 +14794,9 @@
     ],
     "genericFamily": "sans-serif",
     "subsets": [
-      "latin",
-      "latin-ext"
+      "latin-ext",
+      "latin"
     ],
-    "bodyText": false
+    "bodyText": true
   }
 ]


### PR DESCRIPTION
Google's added a bunch of fonts and removed several others, and we rely heavily on the cached data.

This diff also applies loosens the logic to the `bodyText` logic such that fonts that are not mentioned are assumed to be valid header fonts (i.e. fonts default to "valid header" instead of defaulting to "body only")