### PR TITLE
Fix dropdown carat css borders

### DIFF
--- a/css/fonts-customizer.css
+++ b/css/fonts-customizer.css
@@ -44,7 +44,7 @@ h3.jetpack-fonts__type-header {
 	cursor: pointer;
 	border-radius: 0 2px 2px 0;
 	color: #6A6A6A;
-	background-color: #fff;
+	background-color: transparent;
 	font-size: 24px;
 	width: 32px;
 	height: 45px;
@@ -71,7 +71,7 @@ h3.jetpack-fonts__type-header {
 	bottom: 44px;
 	position: absolute;
 	z-index: 11;
-	background-color: #FFFFFF;
+	background-color: #fff;
 	line-height: 2.2;
 	width: 100%;
 	box-sizing: border-box;
@@ -197,7 +197,7 @@ h3.jetpack-fonts__type-header {
 .jetpack-fonts__default-button {
 	cursor: pointer;
 	border-radius: 0 3px 3px 0;
-	background-color: #fff;
+	background-color: transparent;
 	color: #555;
 	font-size: 24px;
 	width: 28px;

--- a/src/css/fonts-customizer.css
+++ b/src/css/fonts-customizer.css
@@ -44,7 +44,7 @@ h3.jetpack-fonts__type-header {
 	cursor: pointer;
 	border-radius: 0 2px 2px 0;
 	color: #6A6A6A;
-	background-color: #fff;
+	background-color: transparent;
 	font-size: 24px;
 	width: 32px;
 	height: 45px;
@@ -71,7 +71,7 @@ h3.jetpack-fonts__type-header {
 	bottom: 44px;
 	position: absolute;
 	z-index: 11;
-	background-color: #FFFFFF;
+	background-color: #fff;
 	line-height: 2.2;
 	width: 100%;
 	box-sizing: border-box;
@@ -197,7 +197,7 @@ h3.jetpack-fonts__type-header {
 .jetpack-fonts__default-button {
 	cursor: pointer;
 	border-radius: 0 3px 3px 0;
-	background-color: #fff;
+	background-color: transparent;
 	color: #555;
 	font-size: 24px;
 	width: 28px;


### PR DESCRIPTION
Removes redundant background coloring that was clobbering the parent element's border coloring.

**Before**
![Screenshot(3)](https://user-images.githubusercontent.com/811776/63680094-32f1b000-c836-11e9-9347-52f702da3726.png)
![Screenshot(2)](https://user-images.githubusercontent.com/811776/63680095-338a4680-c836-11e9-9a05-8f079e50b4c6.png)


**After**
![Screenshot(1)](https://user-images.githubusercontent.com/811776/63680108-3b49eb00-c836-11e9-9bf8-65ccc705fddc.png)
![Screenshot](https://user-images.githubusercontent.com/811776/63680109-3b49eb00-c836-11e9-878c-576b22f18210.png)
