### PR TITLE
Only output custom fonts on non-AMP pages

### DIFF
--- a/custom-fonts.php
+++ b/custom-fonts.php
@@ -236,7 +236,7 @@ class Jetpack_Fonts {
 	 * * @param bool $force  force the fonts to display in a customize preview
 	 * */
 	public function maybe_render_fonts( $force = false ) {
-		if ( ( is_customize_preview() && ! $force ) || ! $this->get_fonts() ) {
+		if ( ( is_customize_preview() && ! $force ) || ! $this->get_fonts() || ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) ) {
 			return;
 		}
 


### PR DESCRIPTION
The fonts get loaded on AMP pages and AMP Stories, causing issues in the AMP validator. [See this issue on the AMP repo](https://github.com/ampproject/amp-wp/issues/3321) for more history.

### To reproduce issue:
- On a WPCOM site, select a custom font in the Customizer.
- In AMP > General settings, enable Stories.
- Create an AMP story and view it, or view a post in AMP mode. In the validator, you should see an error similar to this:
<img width="1360" alt="Screen Shot 2019-09-23 at 3 55 11 PM" src="https://user-images.githubusercontent.com/7317227/65469196-5a2ea380-de1b-11e9-9f5f-fd8ed62901c2.png">

### Recommended solution
- Special handling on AMP pages. This PR just doesn't output custom fonts on AMP pages (they currently get stripped anyways). [A better, future solution might use amp-font](https://amp.dev/documentation/components/amp-font/).