### PR TITLE
Add khmer font subset to allow Cambodian fonts to load correctly

### DIFF
--- a/providers/google.php
+++ b/providers/google.php
@@ -243,6 +243,8 @@ class Jetpack_Google_Font_Provider extends Jetpack_Font_Provider {
 			$subset_string .= ',devanagari';
 		} elseif ( 'vietnamese' === $subset ) {
 			$subset_string .= ',vietnamese';
+		} elseif ( 'khmer' === $subset ) {
+			$subset_string = 'khmer'; // Cambodian fonts won't load if subset of latin.
 		}
 		return $subset_string;
 	}


### PR DESCRIPTION
Currently any khmer fonts get flagged as `inactive` as the browser is not able to verify they are loading using the default latin character set.

This fix correctly flags these fonts as subset khmer to resolve this.

### To test

- Switch a site to Cambodian
- Set custom fonts to Siemreap & Battambang
- Check that the custom fonts load correctly in the front end

Fixes: https://github.com/Automattic/dotcom-manage/issues/117