### PR TITLE
Add new Google fonts

### DIFF
--- a/Providers.md
+++ b/Providers.md
@@ -79,13 +79,17 @@ The font's user-readable name, to display in the dropdown list
 
 Lists all of a font's variants following the [Font Variant Description](https://github.com/typekit/fvd).
 
+### genericFamily
+
+Font family type: `cursive`, `serif`, `monospace`, or `sans-serif`
+
 ### languages
 
 Country codes the language supports
 
 ### subsets
 
-Available subsets for the font, like `latin`, `latin-ext`, `cyrillic`, etc.
+Available subsets for the font, like `latin`, `latin-ext`, `cyrillic`, etc. See: https://fonts.googleapis.com/css?family={font-family-name}
 
 ## Create a JavaScript Custom Fonts provider
 

--- a/providers/google.json
+++ b/providers/google.json
@@ -3408,6 +3408,23 @@
     "bodyText": true
   },
   {
+    "id": "Courier+Prime",
+    "cssName": "Courier Prime",
+    "displayName": "Courier Prime",
+    "fvds": [
+      "n4",
+      "i4",
+      "n7",
+      "i7"
+    ],
+    "genericFamily": "monospace",
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ],
+    "bodyText": true
+  },
+  {
     "id": "Cousine",
     "cssName": "Cousine",
     "displayName": "Cousine",

--- a/providers/google.php
+++ b/providers/google.php
@@ -13,7 +13,7 @@ class Jetpack_Google_Font_Provider extends Jetpack_Font_Provider {
 	 */
 	public function __construct( Jetpack_Fonts $custom_fonts ) {
 		parent::__construct( $custom_fonts );
-		add_filter( 'jetpack_fonts_whitelist_' . $this->id, array( $this, 'default_whitelist' ), 9 );
+		add_filter( 'jetpack_fonts_whitelist_' . $this->id, array( $this, 'default_allowlist' ), 9 );
 	}
 
 	public function get_additional_data() {
@@ -22,35 +22,59 @@ class Jetpack_Google_Font_Provider extends Jetpack_Font_Provider {
 		);
 	}
 
-	public function body_font_whitelist(){
+	/**
+	 * Define fonts that can be selected as body fonts.
+	 * @return array List of font IDs from google.json
+	 */
+	public function body_font_allowlist() {
 		return array(
 			'Alegreya',
 			'Alegreya+Sans',
 			'Anonymous+Pro',
 			'Arimo',
+			'Arvo',
+			'Cabin',
+			'Chivo',
+			'Courier+Prime',
+			'EB+Garamond',
 			'Exo+2',
+			'Fira+Sans',
 			'Gentium+Book+Basic',
+			'Josefin+Sans',
 			'Karla',
 			'Lato',
-			'Lora',
 			'Libre+Baskerville',
+			'Libre+Franklin',
+			'Lora',
 			'Merriweather',
 			'Merriweather+Sans',
 			'Noticia+Text',
 			'Noto+Sans',
 			'Noto+Serif',
+			'Nunito',
 			'Open+Sans',
+			'Overpass',
+			'Poppins',
 			'PT+Sans',
 			'PT+Serif',
 			'Quattrocento+Sans',
+			'Raleway',
+			'Roboto',
+			'Rubik',
 			'Source+Code+Pro',
 			'Source+Sans+Pro',
+			'Space+Mono',
 			'Ubuntu',
 			'Vollkorn',
+			'Work+Sans',
 		);
 	}
 
-	public function headings_font_whitelist(){
+	/**
+	 * Define fonts that can be selected as heading fonts.
+	 * @return array List of font IDs from google.json
+	 */
+	public function headings_font_allowlist() {
 		return array(
 			'Abril+Fatface',
 			'Cherry+Swash',
@@ -66,8 +90,12 @@ class Jetpack_Google_Font_Provider extends Jetpack_Font_Provider {
 		);
 	}
 
-	public function default_whitelist( $whitelist ) {
-		$all_fonts = array_merge ( $this->body_font_whitelist(), $this->headings_font_whitelist() );
+	/**
+	 * Define fonts that can be selected.
+	 * @return array List of font IDs from google.json
+	 */
+	public function default_allowlist( $allowlist ) {
+		$all_fonts = array_merge( $this->body_font_allowlist(), $this->headings_font_allowlist() );
 		return $all_fonts;
 	}
 
@@ -118,8 +146,8 @@ class Jetpack_Google_Font_Provider extends Jetpack_Font_Provider {
 			// This excludes fonts from the body list in the files that we cache,
 			// so lets be conservative here and only exclude fonts that are
 			// explicitly listed as header fonts but not body fonts.
-			'bodyText' => in_array( urlencode( $font['family'] ), $this->body_font_whitelist() ) ||
-			              ! in_array( urlencode( $font['family'] ), $this->headings_font_whitelist() )
+			'bodyText' => in_array( urlencode( $font['family'] ), $this->body_font_allowlist(), ) ||
+						! in_array( urlencode( $font['family'] ), $this->headings_font_allowlist(), ),
 		);
 		return $formatted;
 	}


### PR DESCRIPTION
### Description

We've decided to offer additional fonts on WordPress.com. Git issue: https://github.com/Automattic/dotcom-manage/issues/111
This adds the new fonts to the Customizer (Design > Customizer > Fonts):
![image](https://user-images.githubusercontent.com/1689238/89952848-f613fa00-dbfb-11ea-9c4a-16c2073d9adb.png)

This change will also need to be made to the custom-fonts plugin in wpcom: D47961-code

### Testing
- To get the Customizer interface working only (no actual font functionality, but you can see the changes to the dropdowns), comment out lines 125-128 in custom-fonts.php:
https://github.com/Automattic/custom-fonts/blob/e6a49fc62f51d4c234ebcef95ff82c1642061a23/custom-fonts.php#L125-L128
- To get the custom fonts plugin working, download a premium theme like "Atlas" from your wpcom sandbox and activate it on your local development site.
- Go to Design > Customizer > Fonts
- The Headings font list should include:
			'Abril+Fatface',
                        'Alegreya',
			'Alegreya+Sans',
			'Anonymous+Pro',
			'Arimo',
			'Arvo',
			'Cabin',
                        'Cherry+Swash',
			'Chivo',
			'Cinzel',
			'Courier+Prime',
			'EB+Garamond',
			'Exo+2',
			'Fira+Sans',
                        'Fondamento',
			'Gentium+Book+Basic',
			'Josefin+Sans',
			'Karla',
			'Lato',
			'Libre+Baskerville',
			'Libre+Franklin',
                        'Lobster+Two',
			'Lora',
			'Merriweather',
			'Merriweather+Sans',
                        'Montserrat',
			'Muli',
			'Noticia+Text',
			'Noto+Sans',
			'Noto+Serif',
			'Nunito',
			'Open+Sans',
                        'Oswald',
			'Overpass',
			'Poppins',
			'PT+Sans',
			'PT+Serif',
                        'Playfair+Display',
			'Quattrocento+Sans',
			'Raleway',
			'Roboto',
			'Roboto+Slab',
			'Rubik',
			'Source+Code+Pro',
			'Source+Sans+Pro',
			'Space+Mono',
                        'Tangerine',
			'Ubuntu',
			'Vollkorn',
			'Work+Sans',

- The Base font list should include:
                        'Alegreya',
			'Alegreya+Sans',
			'Anonymous+Pro',
			'Arimo',
			'Arvo',
			'Cabin',
			'Chivo',
			'Courier+Prime',
			'EB+Garamond',
			'Exo+2',
			'Fira+Sans',
			'Gentium+Book+Basic',
			'Josefin+Sans',
			'Karla',
			'Lato',
			'Libre+Baskerville',
			'Libre+Franklin',
			'Lora',
			'Merriweather',
			'Merriweather+Sans',
			'Noticia+Text',
			'Noto+Sans',
			'Noto+Serif',
			'Nunito',
			'Open+Sans',
			'Overpass',
			'Poppins',
			'PT+Sans',
			'PT+Serif',
			'Quattrocento+Sans',
			'Raleway',
			'Roboto',
			'Rubik',
			'Source+Code+Pro',
			'Source+Sans+Pro',
			'Space+Mono',
			'Ubuntu',
			'Vollkorn',
			'Work+Sans',
- All of the fonts should have previews in the dropdowns
- Changing the fonts should change the site heading and base fonts in the Customizer preview
- Changing the fonts and then saving should change the site heading and base fonts on the site