### PR TITLE
Google Provider: Fix allowed font test

### DIFF
--- a/tests/php/google-provider-Test.php
+++ b/tests/php/google-provider-Test.php
@@ -53,18 +53,23 @@ class Jetpack_Google_Font_Provider_Test extends PHPUnit_Framework_TestCase {
 					},
 					{
 						"kind": "webfonts#webfont",
-						"family": "Antic",
-						"category": "sans-serif",
+						"family": "Cinzel",
+						"category": "serif",
 						"variants": [
-							"regular"
+							"regular",
+							"700",
+							"900"
 						],
 						"subsets": [
+	 					    "latin-ext",
 							"latin"
 						],
-						"version": "v4",
-						"lastModified": "2012-07-25",
+					    "version": "v9",
+					    "lastModified": "2019-07-17",
 						"files": {
-							"regular": "http://themes.googleusercontent.com/static/fonts/antic/v4/hEa8XCNM7tXGzD0Uk0AipA.ttf"
+							"regular": "http://fonts.gstatic.com/s/cinzel/v9/8vIJ7ww63mVu7gtL8W76HEdHMg.ttf",
+							"700": "http://fonts.gstatic.com/s/cinzel/v9/8vIK7ww63mVu7gtzTUHeFGxbO_zo-w.ttf",
+							"900": "http://fonts.gstatic.com/s/cinzel/v9/8vIK7ww63mVu7gtzdUPeFGxbO_zo-w.ttf"
 						}
 					}
 				]


### PR DESCRIPTION
The body text property of a font is set to `false` when it's not allowed
as a body font, but is allowed as a header font. The test font of Antic
wasn't allowed as either so shouldn't have been allowed but because it
wasn't explicitly a header font, the logic returned true.

This change updates the test font to one that meets the criteria of
being a header font but not a body font.

It's possible that we should update this logic to so that both
conditions should be true. The body text property will be set to true
for all fonts that aren't heading fonts currently.

## Testing

Run the tests with `npm run tests` with and without this change. The `test_retreive_fonts_returns_false_body_text_if_not_whitelisted` test will fail without this change, and should pass with it.