### PR TITLE
Bump version to 1.0.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
   "name": "automattic/custom-fonts",
-  "version": "v1.0.6",
+  "version": "v1.0.7",
   "autoload": {
   	"files": [ "custom-fonts.php" ]
   },


### PR DESCRIPTION
This includes a change (#308) to ensure that versions of PHP < 7.3 will not
produce syntax errors in the Google Provider