### PR TITLE
Add Spartan to imported Google fonts

### DIFF
--- a/providers/google.json
+++ b/providers/google.json
@@ -13191,6 +13191,28 @@
     "bodyText": true
   },
   {
+    "id": "Spartan",
+    "cssName": "Spartan",
+    "displayName": "Spartan",
+    "fvds": [
+      "n1",
+      "n2",
+      "n3",
+      "n4",
+      "n5",
+      "n6",
+      "n7",
+      "n8",
+      "n9"
+    ],
+    "genericFamily": "sans-serif",
+    "subsets": [
+      "latin",
+      "latin-ext"
+    ],
+    "bodyText": true
+  },
+  {
     "id": "Special+Elite",
     "cssName": "Special Elite",
     "displayName": "Special Elite",


### PR DESCRIPTION
Fixes https://github.com/Automattic/dotcom-manage/issues/189

## Description
- Add "Spartan" to the Google fonts we import so that it can replace Typekit font Futura PT, which we're removing as part of the [Sunsetting Typekit milestone](https://github.com/Automattic/dotcom-manage/milestone/1)

This change will also need to be made to the custom-fonts plugin in wpcom: D48802-code

<img width="863" alt="Screen Shot 2020-08-28 at 5 19 10 PM" src="https://user-images.githubusercontent.com/1689238/91615906-a13de680-e952-11ea-8c7f-6fcc2a7d15c0.png">


## Testing
To get the custom fonts plugin working locally, download a premium theme like "Atlas" from your wpcom sandbox and activate it on your local development site.

Go to Design > Customizer > Fonts and verify that you can change fonts and they load as expected.

You can also add `'Spartan',` to `body_font_allowlist()` in providers/google.php and check that the font is actually loaded when selected.