### PR TITLE
Enable the typekit to google mappings for all users

### DIFF
--- a/custom-fonts.php
+++ b/custom-fonts.php
@@ -100,14 +100,6 @@ class Jetpack_Fonts {
 
 		// Load the deprecated typkit font mapper.
 		require dirname( __FILE__ ) . '/providers/deprecated-typekit.php';
-
-		// Temporary cookie option for testing typekit font mappings.
-		if ( isset( $_GET['enable-google-fonts-preview'] ) && ! isset( $_COOKIE['preview-google-fonts'] ) ) {
-			setcookie( 'preview-google-fonts', true, time() + 900, '/' );
-		}
-		if ( ( isset( $_GET['disable-google-fonts-preview'] ) || isset( $_GET['update-typekit-selection'] ) ) && isset( $_COOKIE['preview-google-fonts'] ) ) {
-			setcookie( 'preview-google-fonts', true, time() - 3600, '/' );
-		}
 	}
 
 	public function add_preview_scripts() {
@@ -172,7 +164,7 @@ class Jetpack_Fonts {
 
 		if ( $this->previous_setting
 			&& ( isset( $this->previous_setting['typekit_kit_id'] ) || $this->has_typekit_font_selected() )
-			&& ( ! isset( $this->previous_setting['deprecated_typekit_fonts'] ) || isset( $_GET['update-typekit-selection'] ) ) ) {
+			&& ! isset( $this->previous_setting['deprecated_typekit_fonts'] ) ) {
 			$this->set( 'deprecated_typekit_fonts', $this->previous_setting['selected_fonts'] );
 		}
 	}
@@ -341,7 +333,7 @@ EMBED;
 		$keyed = array();
 
 		foreach ( $fonts as $font ) {
-			if ( 'typekit' === $font['provider'] && isset( $_COOKIE['preview-google-fonts'] ) ) {
+			if ( 'typekit' === $font['provider'] ) {
 				$font = Jetpack_Fonts_Typekit_Font_Mapper::get_mapped_google_font( $font );
 			}
 			$provider = $font['provider'];
@@ -653,9 +645,7 @@ EMBED;
 			return $fonts_for_js;
 		}
 		foreach( $fonts as $font ) {
-			if ( 'typekit' === $font['provider']
-				&& ( ( isset( $_COOKIE['preview-google-fonts'] ) && ! isset( $_GET['disable-google-fonts-preview'] ) )
-				|| isset( $_GET['enable-google-fonts-preview'] ) ) ) {
+			if ( 'typekit' === $font['provider'] ) {
 				$font = Jetpack_Fonts_Typekit_Font_Mapper::get_mapped_google_font( $font );
 			}
 			$provider  = $this->get_provider( $font['provider'] );


### PR DESCRIPTION
The easiest way to test this is using an [Atomic Ephemeral Site](https://mc.a8c.com/atomic/ephemeral-sites/):

- Set up a new ephemeral atomic site
- Add and activate this Affinity theme - [affinity.zip](https://github.com/Automattic/custom-fonts/files/5165897/affinity.zip)
- Check out this branch and add the `define( 'WPCOM_TYPEKIT_API_TOKEN'` constant declaration from your Sandbox to the /.config/secrets.php file to the top of custom-fonts.php file
- Bring up Fonts menu on customizer and add `?update-typekit-selection` to url and reload
- Select typekit fonts, save and reload with query param still in place
- With sftp copy the changes from this branch, and https://github.com/Automattic/custom-fonts-typekit/pull/97 in the remote site under respective plugin folders in mu-plugins/wpcomsh/vendor/automattic/
- Reload customizer and check that now that mapped google fonts display by default and that the 'Premium Fonts by Adobe Typekit' badge does not appear on customizer font screen
- Make sure you can select other fonts and save ok

before:
<img width="238" alt="before" src="https://user-images.githubusercontent.com/3629020/96526779-0f5fb380-12db-11eb-8aac-829dc1252c3b.png">

after:
<img width="254" alt="after" src="https://user-images.githubusercontent.com/3629020/96526784-11c20d80-12db-11eb-94f7-c3efa8430318.png">

Complimentary diff for testing Simple Sites at D51445-code