### PR TITLE
Move theme compatability filter from custom-fonts-typekit plugin

### DIFF
--- a/annotation-compat.php
+++ b/annotation-compat.php
@@ -1,0 +1,32 @@
+<?php
+
+// add late, see if we need to shim in rules
+add_action( 'jetpack_fonts_rules', 'wpcom_font_rules_compat', 20 );
+function wpcom_font_rules_compat( $rules ) {
+	if ( $rules->has_rules() ) {
+		return;
+	}
+
+	// first, if we already have filters, we are in business
+	if ( has_filter( 'typekit_add_font_category_rules' ) ) {
+		return wpcom_load_legacy_font_category_rules( $rules );
+	}
+
+	// ok, load 'em up
+	$annotations_base = apply_filters( 'wpcom_font_rules_location_base', WPMU_PLUGIN_DIR . '/custom-fonts/theme-annotations' );
+	$annotations_file = trailingslashit( $annotations_base ) . get_stylesheet() . '.php';
+	if ( ! file_exists( $annotations_file ) && is_child_theme() ) {
+		$annotations_file = trailingslashit( $annotations_base ) . get_template() . '.php';
+	}
+	if ( file_exists( $annotations_file ) ) {
+		include_once $annotations_file;
+		wpcom_load_legacy_font_category_rules( $rules );
+	}
+}
+
+function wpcom_load_legacy_font_category_rules( $rules ) {
+	require_once __DIR__ . '/typekit-theme-mock.php';
+	TypekitTheme::$rules_dependency = $rules;
+	TypekitTheme::$allowed_categories = $rules->get_allowed_types();
+	apply_filters( 'typekit_add_font_category_rules', array() );
+}

--- a/custom-fonts.php
+++ b/custom-fonts.php
@@ -90,6 +90,7 @@ class Jetpack_Fonts {
 	 * @return void
 	 */
 	public function init() {
+		require_once __DIR__ . '/annotation-compat.php';
 		add_action( 'setup_theme', array( $this, 'register_providers' ), 11 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'maybe_render_fonts' ) );
 		add_action( 'customize_register', array( $this, 'register_controls' ) );


### PR DESCRIPTION
The `custom-font-typekit` plugin is largely unused after sunsetting the typekit fonts, except for an annotations compatibility filter that is used by some themes. It converts existing typekit based font annotations within themes for compatibility with with new custom fonts.

This diff adds the filter (annotation-compat.php) as well as the required Typekit class (typekit-theme-mock.php) from `custom-font-typekit` to the `custom-font` plugin, in preparation for the removal of `custom-font-typekit`.

It works in conjunction with https://github.com/Automattic/custom-fonts-typekit/pull/101, which removes reference to the old filter in `custom-font-typekit`.

Note: A typekit-theme-mock.php file already existed in the custom-font plugin but was unused. It was deleted and replaced with the file from `custom-font-typekit`; the diff shows the difference between the two.

### Test:
- Check out this PR locally as well as https://github.com/Automattic/custom-fonts-typekit/pull/101
- Using a test site with the Adaline theme, go to the Customizer and verify that the page loads
- Test selecting/saving new fonts

Fixes https://github.com/Automattic/view-design/issues/114