### PR TITLE
Fix linting issues from WPCOM commit

### DIFF
--- a/tests/php/css-generator-Test.php
+++ b/tests/php/css-generator-Test.php
@@ -116,17 +116,28 @@ class Jetpack_Fonts_Css_Generator_Test extends PHPUnit_Framework_TestCase {
 			)
 		);
 		\WP_Mock::setUp();
-		\WP_Mock::userFunction( '__', array(
-			'return_arg' => '0'
-		) );
+		\WP_Mock::userFunction(
+			'__',
+			array(
+				'return_arg' => '0'
+			)
+		);
 		$this->generator = new Jetpack_Fonts_Css_Generator;
-		\WP_Mock::userFunction( 'get_stylesheet_directory', array(
-			'return' => dirname( __FILE__ ) . '/../../../../themes/twentyfourteen'
-		) );
-		\WP_Mock::userFunction( 'is_child_theme', array(
-			'return' => false
-		) );
-		\WP_Mock::onAction( 'jetpack_fonts_rules' )->with( $this->generator )->perform( array( $this, 'jetpack_fonts_rules' ) );
+		\WP_Mock::userFunction(
+			'get_stylesheet_directory',
+			array(
+				'return' => dirname( __FILE__ ) . '/../../../../themes/twentyfourteen'
+			)
+		);
+		\WP_Mock::userFunction(
+			'is_child_theme',
+			array(
+				'return' => false
+			)
+		);
+		\WP_Mock::onAction( 'jetpack_fonts_rules' )
+			->with( $this->generator )
+			->perform( array( $this, 'jetpack_fonts_rules' ) );
 	}
 
 	public function jetpack_fonts_rules() {


### PR DESCRIPTION
This PR addresses some linting issues that were flagged while I was committing D85544-code to WordPress.com.

I don't think we need to push these changes downstream to Automattic/wpcomsh or to WordPress.com, but we can choose to do that. For this specific change, I am not sure it's worth it, given that this has no functional impact.