### PR TITLE
Avoid PHP notice by returning integer from comparison callback

### DIFF
--- a/custom-fonts.php
+++ b/custom-fonts.php
@@ -441,7 +441,7 @@ EMBED;
 	}
 
 	public function sort_by_display_name( $a, $b ) {
-		return $a['displayName'] > $b['displayName'];
+		return $a['displayName'] > $b['displayName'] ? 1 : -1;
 	}
 
 	/**


### PR DESCRIPTION
From usort docs:

> The comparison function must return an integer less than, equal to, or greater than zero
> —https://www.php.net/manual/en/function.usort.php