### PR TITLE
TypekitTheme: Fix PHP 8.1 warnings related to undefined key property

### DIFF
--- a/typekit-theme-mock.php
+++ b/typekit-theme-mock.php
@@ -45,7 +45,7 @@ class TypekitTheme {
 	private static function maybe_split_font_shorthand( $declarations ) {
 		$split_declations = array();
 		foreach ( $declarations as $i => $declaration ) {
-			if ( 'font' === $declaration['property'] ) {
+			if ( isset( $declaration['property'] ) && 'font' === $declaration['property'] ) {
 				$split_declation = self::split_font_shorthand( $declaration['value'] );
 				if ( ! empty( $split_declation ) ) {
 					$split_declations = array_merge( $split_declations, $split_declation );


### PR DESCRIPTION
* TypekitTheme: Fix PHP 8.1 warnings related to undefined key property
* Test via: Manual inspection
* See also: D136646-code