### PR TITLE
Improve phpdoc return type for `Jetpack_Fonts::get_instance()`

### DIFF
--- a/custom-fonts.php
+++ b/custom-fonts.php
@@ -77,7 +77,7 @@ class Jetpack_Fonts {
 	 * Retrieve the single instance of this class, creating if
 	 * not previously instantiated.
 	 *
-	 * @return object Jetpack_Fonts instance
+	 * @return self Jetpack_Fonts instance
 	 */
 	public static function get_instance() {
 		if ( ! self::$instance ) {


### PR DESCRIPTION
It returns a `new self()`, the phpdoc should reflect that so static analysis tools can be more accurate.