### PR TITLE
Fix PHP 8.4 deprecation of implicit nullable parameters

### DIFF
--- a/custom-fonts.php
+++ b/custom-fonts.php
@@ -816,7 +816,7 @@ EMBED;
 	/**
 	 * Silence is golden
 	 */
-	public function __construct( Jetpack_Fonts_Css_Generator $generator = null ) {
+	public function __construct( ?Jetpack_Fonts_Css_Generator $generator = null ) {
 		$this->generator = $generator;
 	}
 }


### PR DESCRIPTION
PHP 8.4 deprecated implicit nullable parameters, i.e. `Class $var = null`. You now have to explicitly make them nullable, i.e. `?Class $var = null`.